### PR TITLE
Fix rsyslog for fedora.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,6 +12,16 @@ when 'fedora'
   default['openstack']['db']['python_packages']['mysql'] = [ 'MySQL-python' ]
   default['openstack']['yum']['uri'] = "http://repos.fedorapeople.org/repos/openstack/openstack-#{node['openstack']['release']}/fedora-20"
   default['openstack']['yum']['repo-key'] = "https://github.com/redhat-openstack/rdo-release/raw/master/RPM-GPG-KEY-RDO-#{node['openstack']['release'].capitalize}"
+  # Fix for rsyslog to not pipe to /dev/xconsole
+  default['rsyslog']['default_facility_logs'] = {
+    '*.info;mail.none;authpriv.none;cron.none' => "#{node['rsyslog']['default_log_dir']}/messages",
+    'authpriv.*' => "#{node['rsyslog']['default_log_dir']}/secure",
+    'mail.*' => "-#{node['rsyslog']['default_log_dir']}/maillog",
+    'cron.*' => "#{node['rsyslog']['default_log_dir']}/cron",
+    '*.emerg' => '*',
+    'uucp,news.crit' => "#{node['rsyslog']['default_log_dir']}/spooler",
+    'local7.*' => "#{node['rsyslog']['default_log_dir']}/boot.log"
+  }
 when 'centos'
   default['openstack']['yum']['uri'] = "http://repos.fedorapeople.org/repos/openstack/openstack-#{node['openstack']['release']}/epel-6"
   default['openstack']['yum']['repo-key'] = "https://github.com/redhat-openstack/rdo-release/raw/master/RPM-GPG-KEY-RDO-#{node['openstack']['release'].capitalize}"


### PR DESCRIPTION
Rsyslog defaults some messages to pipe to /dev/xconsole if the systems is not rhel. 

https://github.com/opscode-cookbooks/rsyslog/blob/master/attributes/default.rb

Since the openpower nodes are on fedora it is causing the rsyslog process to lock up. We should set it the same as rhel.

EDIT: Trying to test but having issues with test kitchen.
