### PR TITLE
Cinder Support

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -50,11 +50,11 @@ provisioner:
       disabled: true
 
 platforms:
-- name: centos-6.5
+- name: centos-6.6
   driver_plugin: openstack
   driver_config:
     username: centos
-    image_ref: "CentOS 6.5"
+    image_ref: "CentOS 6.6"
     attributes:
       mysql:
         version: 5.1
@@ -92,6 +92,19 @@ suites:
       - role[base_managed]
       - recipe[osl-openstack::compute]
       - role[openstack_compute]
+  - name: cinder
+    run_list:
+      - role[openstack_base]
+      - role[openstack_ops_database]
+      - recipe[openstack-ops-messaging::server]
+      - recipe[openstack-identity::server]
+      - recipe[openstack-identity::registration]
+      - recipe[osl-openstack::cinder]
+    attributes:
+      openstack:
+        block-storage:
+          volume:
+            create_volume_group: true
   - name: novnc
     run_list:
       - role[openstack_ops_database]

--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -101,6 +101,9 @@ suites:
       - recipe[openstack-identity::registration]
       - recipe[osl-openstack::cinder]
     attributes:
+      osl-openstack:
+        cinder:
+          iscsi_role: "openstack_base"
       openstack:
         block-storage:
           volume:

--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -104,6 +104,9 @@ suites:
       osl-openstack:
         cinder:
           iscsi_role: "openstack_base"
+          iscsi_ips:
+            - 127.0.2.1
+            - 127.0.3.1
       openstack:
         block-storage:
           volume:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -82,6 +82,9 @@ suites:
       osl-openstack:
         cinder:
           iscsi_role: "openstack_base"
+          iscsi_ips:
+            - 127.0.2.1
+            - 127.0.3.1
       openstack:
         block-storage:
           volume:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -41,7 +41,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
-  - name: centos-6.5
+  - name: centos-6.6
     attributes:
       mysql:
         version: 5.1
@@ -70,6 +70,22 @@ suites:
       - role[base_managed]
       - recipe[osl-openstack::compute]
       - role[openstack_compute]
+  - name: cinder
+    run_list:
+      - role[openstack_base]
+      - role[openstack_ops_database]
+      - recipe[openstack-ops-messaging::server]
+      - recipe[openstack-identity::server]
+      - recipe[openstack-identity::registration]
+      - recipe[osl-openstack::cinder]
+    attributes:
+      osl-openstack:
+        cinder:
+          iscsi_role: "openstack_base"
+      openstack:
+        block-storage:
+          volume:
+            create_volume_group: true
   - name: novnc
     run_list:
       - role[openstack_ops_database]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,10 @@
+AllCops:
+  Include:
+    - '**/Berksfile'
+    - '**/Cheffile'
+  Exclude:
+    - 'metadata.rb'
+
+Lint/AmbiguousRegexpLiteral:
+  Exclude:
+    - 'test/integration/**/*.rb'

--- a/Berksfile
+++ b/Berksfile
@@ -14,6 +14,8 @@ cookbook "nagios", git: "git@github.com:osuosl-cookbooks/nagios"
 cookbook "omnibus_updater"
 cookbook "osl-apache", git: "git@github.com:osuosl-cookbooks/osl-apache"
 cookbook "osl-munin", git: "git@github.com:osuosl-cookbooks/osl-munin"
+cookbook 'resource_from_hash',
+         git: 'git@github.com:osuosl-cookbooks/resource_from_hash'
 cookbook "runit", "1.5.10"
 cookbook "statsd", github: "att-cloud/cookbook-statsd"
 cookbook "yum", ">= 3.1.4"

--- a/Berksfile
+++ b/Berksfile
@@ -1,35 +1,36 @@
-source 'https://supermarket.getchef.com'
+source 'https://supermarket.chef.io'
 
 # OSL Base deps
-cookbook "aliases", git: "git@github.com:osuosl-cookbooks/aliases"
-cookbook "apt", ">= 2.3.8"
-cookbook "apache2", "< 2.0.0"
-cookbook "base", git: "git@github.com:osuosl-cookbooks/base"
-cookbook "database", ">= 2.0.0"
-cookbook "firewall", git: "git@github.com:osuosl-cookbooks/firewall"
-cookbook "modules", git: "git@github.com:osuosl-cookbooks/modules-cookbook"
-cookbook "monitoring", git: "git@github.com:osuosl-cookbooks/monitoring"
-cookbook "munin"
-cookbook "nagios", git: "git@github.com:osuosl-cookbooks/nagios"
-cookbook "omnibus_updater"
-cookbook "osl-apache", git: "git@github.com:osuosl-cookbooks/osl-apache"
-cookbook "osl-munin", git: "git@github.com:osuosl-cookbooks/osl-munin"
+cookbook 'aliases', git: 'git@github.com:osuosl-cookbooks/aliases'
+cookbook 'apt', '>= 2.3.8'
+cookbook 'apache2', '< 2.0.0'
+cookbook 'base', git: 'git@github.com:osuosl-cookbooks/base'
+cookbook 'database', '>= 2.0.0'
+cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
+cookbook 'modules', git: 'git@github.com:osuosl-cookbooks/modules-cookbook'
+cookbook 'monitoring', git: 'git@github.com:osuosl-cookbooks/monitoring'
+cookbook 'munin'
+cookbook 'nagios', git: 'git@github.com:osuosl-cookbooks/nagios'
+cookbook 'omnibus_updater'
+cookbook 'osl-apache', git: 'git@github.com:osuosl-cookbooks/osl-apache'
+cookbook 'osl-munin', git: 'git@github.com:osuosl-cookbooks/osl-munin'
 cookbook 'resource_from_hash',
          git: 'git@github.com:osuosl-cookbooks/resource_from_hash'
-cookbook "runit", "1.5.10"
-cookbook "statsd", github: "att-cloud/cookbook-statsd"
-cookbook "yum", ">= 3.1.4"
-cookbook "yum-epel", ">= 0.3.4"
+cookbook 'runit', '1.5.10'
+cookbook 'statsd', github: 'att-cloud/cookbook-statsd'
+cookbook 'yum', '>= 3.1.4'
+cookbook 'yum-epel', '>= 0.3.4'
 
 # Openstack deps
-#cookbook "mysql", "~> 4.1"
+# cookbook 'mysql', '~> 4.1'
 %w(openstack-block-storage openstack-common
-openstack-object-storage openstack-ops-database openstack-ops-messaging
-openstack-orchestration openstack-telemetry openstack-identity openstack-image
-openstack-network openstack-compute openstack-dashboard).each do |cb|
+   openstack-object-storage openstack-ops-database openstack-ops-messaging
+   openstack-orchestration openstack-telemetry openstack-identity
+   openstack-image openstack-network openstack-compute
+   openstack-dashboard).each do |cb|
   cookbook cb,
-    github: "stackforge/cookbook-#{cb}",
-    branch: "stable/icehouse"
+           github: "stackforge/cookbook-#{cb}",
+           branch: 'stable/icehouse'
 end
 
 metadata

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,6 +16,7 @@ default['osl-openstack']['database_suffix'] = nil
 default['osl-openstack']['databag_prefix'] = nil
 default['osl-openstack']['vnc_bind_interface']['controller'] = "eth1"
 default['osl-openstack']['vnc_bind_interface']['compute'] = "br42"
+default['osl-openstack']['cinder']['iscsi_role'] = nil
 
 # Include Fedora attribute fixes that aren't in upstream
 case platform

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@ default['osl-openstack']['databag_prefix'] = nil
 default['osl-openstack']['vnc_bind_interface']['controller'] = "eth1"
 default['osl-openstack']['vnc_bind_interface']['compute'] = "br42"
 default['osl-openstack']['cinder']['iscsi_role'] = nil
+default['osl-openstack']['cinder']['iscsi_ips'] = []
 
 # Include Fedora attribute fixes that aren't in upstream
 case platform

--- a/recipes/cinder.rb
+++ b/recipes/cinder.rb
@@ -19,8 +19,7 @@
 # this is required because of the fedora deps. Will be fixed once its moved into
 # a _common recipe.
 iscsi_hosts = ['127.0.0.1']
-iscsi_hosts += node['osl-openstack']['cinder']['iscsi_ips'] unless
-  node['osl-openstack']['cinder']['iscsi_ips'].empty?
+iscsi_hosts += node['osl-openstack']['cinder']['iscsi_ips']
 iscsi_role = node['osl-openstack']['cinder']['iscsi_role']
 unless iscsi_role.nil? && Chef::Config[:solo]
   search(:node, "role:#{iscsi_role}") do |n|

--- a/recipes/cinder.rb
+++ b/recipes/cinder.rb
@@ -32,7 +32,7 @@ include_recipe 'firewall'
 include_recipe 'firewall::openstack'
 include_recipe 'firewall::iscsi'
 include_recipe 'osl-openstack::default'
-include_recipe 'osl-openstack::_fedora'
+include_recipe 'osl-openstack::_fedora' if platform?('fedora')
 include_recipe 'openstack-block-storage::api'
 include_recipe 'openstack-block-storage::scheduler'
 include_recipe 'openstack-block-storage::volume'

--- a/recipes/cinder.rb
+++ b/recipes/cinder.rb
@@ -20,7 +20,7 @@
 # a _common recipe.
 iscsi_hosts = ['127.0.0.1']
 iscsi_hosts << node['osl-openstack']['cinder']['iscsi_ips'] unless
-  node['osl-openstack']['cinder']['iscsi_ips'].nil?
+  node['osl-openstack']['cinder']['iscsi_ips'].empty?
 iscsi_role = node['osl-openstack']['cinder']['iscsi_role']
 unless iscsi_role.nil? && Chef::Config[:solo]
   search(:node, "role:#{iscsi_role}") do |n|

--- a/recipes/cinder.rb
+++ b/recipes/cinder.rb
@@ -19,7 +19,7 @@
 # this is required because of the fedora deps. Will be fixed once its moved into
 # a _common recipe.
 iscsi_hosts = ['127.0.0.1']
-iscsi_hosts << node['osl-openstack']['cinder']['iscsi_ips'] unless
+iscsi_hosts += node['osl-openstack']['cinder']['iscsi_ips'] unless
   node['osl-openstack']['cinder']['iscsi_ips'].empty?
 iscsi_role = node['osl-openstack']['cinder']['iscsi_role']
 unless iscsi_role.nil? && Chef::Config[:solo]

--- a/recipes/cinder.rb
+++ b/recipes/cinder.rb
@@ -22,7 +22,7 @@ iscsi_hosts = ['127.0.0.1']
 iscsi_hosts << node['osl-openstack']['cinder']['ips'] unless
   node['osl-openstack']['cinder']['ips'].nil?
 iscsi_role = node['osl-openstack']['cinder']['iscsi_role']
-unless iscsi_role.nil?
+unless iscsi_role.nil? && Chef::Config[:solo]
   search(:node, "role:#{iscsi_role}") do |n|
     iscsi_hosts << n['ipaddress']
   end

--- a/recipes/cinder.rb
+++ b/recipes/cinder.rb
@@ -18,6 +18,16 @@
 #
 # this is required because of the fedora deps. Will be fixed once its moved into
 # a _common recipe.
+iscsi_hosts = ['127.0.0.1']
+iscsi_role = node['osl-openstack']['cinder']['iscsi_role']
+unless iscsi_role.nil?
+  search(:node, "role:#{iscsi_role}") do |i|
+    iscsi_hosts << i['ipaddress']
+  end
+end
+
+node.override['firewall']['range']['iscsi'] = iscsi_hosts
+
 include_recipe 'firewall'
 include_recipe 'firewall::openstack'
 include_recipe 'firewall::iscsi'

--- a/recipes/cinder.rb
+++ b/recipes/cinder.rb
@@ -19,8 +19,8 @@
 # this is required because of the fedora deps. Will be fixed once its moved into
 # a _common recipe.
 iscsi_hosts = ['127.0.0.1']
-iscsi_hosts << node['osl-openstack']['cinder']['ips'] unless
-  node['osl-openstack']['cinder']['ips'].nil?
+iscsi_hosts << node['osl-openstack']['cinder']['iscsi_ips'] unless
+  node['osl-openstack']['cinder']['iscsi_ips'].nil?
 iscsi_role = node['osl-openstack']['cinder']['iscsi_role']
 unless iscsi_role.nil? && Chef::Config[:solo]
   search(:node, "role:#{iscsi_role}") do |n|

--- a/recipes/cinder.rb
+++ b/recipes/cinder.rb
@@ -19,6 +19,8 @@
 # this is required because of the fedora deps. Will be fixed once its moved into
 # a _common recipe.
 iscsi_hosts = ['127.0.0.1']
+iscsi_hosts << node['osl-openstack']['cinder']['ips'] unless
+  node['osl-openstack']['cinder']['ips'].nil?
 iscsi_role = node['osl-openstack']['cinder']['iscsi_role']
 unless iscsi_role.nil?
   search(:node, "role:#{iscsi_role}") do |n|

--- a/recipes/cinder.rb
+++ b/recipes/cinder.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: osl-openstack
+# Recipe:: cinder
+#
+# Copyright (C) 2015 Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# this is required because of the fedora deps. Will be fixed once its moved into
+# a _common recipe.
+include_recipe 'firewall'
+include_recipe 'firewall::openstack'
+include_recipe 'firewall::iscsi'
+include_recipe 'osl-openstack::default'
+include_recipe 'osl-openstack::_fedora'
+include_recipe 'openstack-block-storage::api'
+include_recipe 'openstack-block-storage::scheduler'
+include_recipe 'openstack-block-storage::volume'
+include_recipe 'openstack-block-storage::client'
+include_recipe 'openstack-block-storage::identity_registration'

--- a/recipes/cinder.rb
+++ b/recipes/cinder.rb
@@ -21,8 +21,8 @@
 iscsi_hosts = ['127.0.0.1']
 iscsi_role = node['osl-openstack']['cinder']['iscsi_role']
 unless iscsi_role.nil?
-  search(:node, "role:#{iscsi_role}") do |i|
-    iscsi_hosts << i['ipaddress']
+  search(:node, "role:#{iscsi_role}") do |n|
+    iscsi_hosts << n['ipaddress']
   end
 end
 

--- a/test/integration/cinder/serverspec/server_spec.rb
+++ b/test/integration/cinder/serverspec/server_spec.rb
@@ -9,8 +9,8 @@ set :backend, :exec
 ).each do |ip|
   describe iptables do
     it do
-      should have_rule("-A iscsi -s #{ip}/32 -p tcp -m tcp --dport 3260 -j
-ACCEPT")
+      should have_rule("-A iscsi -s #{ip}/32 -p tcp -m tcp --dport 3260 -j " \
+'ACCEPT')
     end
   end
 end

--- a/test/integration/cinder/serverspec/server_spec.rb
+++ b/test/integration/cinder/serverspec/server_spec.rb
@@ -1,0 +1,31 @@
+require 'serverspec'
+
+set :backend, :exec
+
+%w(
+  127.0.0.1
+  127.0.2.1
+  127.0.3.1
+).each do |ip|
+  describe iptables do
+    it do
+      should have_rule("-A iscsi -s #{ip}/32 -p tcp -m tcp --dport 3260 -j
+ACCEPT")
+    end
+  end
+end
+
+# Make sure we can create a volume, it exists and delete it
+cinder = 'source /root/openrc && cinder '
+
+describe command(cinder + ' create --display-name=test-volume 1') do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command(cinder + 'list') do
+  its(:stdout) { should match /test-volume/ }
+end
+
+describe command(cinder + 'delete test-volume') do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/cinder/serverspec/server_spec.rb
+++ b/test/integration/cinder/serverspec/server_spec.rb
@@ -9,8 +9,8 @@ set :backend, :exec
 ).each do |ip|
   describe iptables do
     it do
-      should have_rule("-A iscsi -s #{ip}/32 -p tcp -m tcp --dport 3260 -j " \
-'ACCEPT')
+      should have_rule("-A iscsi -s #{ip}/32 -p tcp -m tcp --dport 3260 " \
+'-j ACCEPT')
     end
   end
 end


### PR DESCRIPTION
This provides Cinder support.

NOTE: This only works on CentOS 6 for testing purposes. I cannot get Fedora 20 working completely because of the database issues.