### PR TITLE
Fix Icehouse RDO url

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -66,6 +66,8 @@ platforms:
   driver_config:
     username: fedora
     image_ref: "Fedora 20"
+  run_list:
+    - recipe[yum-fedora]
 - name: fedora-21
   driver_plugin: openstack
   driver_config:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -45,6 +45,8 @@ platforms:
       mysql:
         version: 5.1
   - name: fedora-20
+    run_list:
+      - recipe[yum-fedora]
   - name: fedora-21
 
 suites:

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,13 +19,13 @@
 case node['platform']
 when 'fedora'
   node.default['openstack']['yum']['uri'] = 'http://repos.fedorapeople.org/' \
-    "repos/openstack/openstack-#{node['openstack']['release']}/fedora-20"
+    "repos/openstack/EOL/openstack-#{node['openstack']['release']}/fedora-20"
   node.default['openstack']['yum']['repo-key'] = 'https://github.com/' \
     "redhat-openstack/rdo-release/raw/#{node['openstack']['release']}/" \
     "RPM-GPG-KEY-RDO-#{node['openstack']['release'].capitalize}"
 when 'centos'
   node.default['openstack']['yum']['uri'] = 'http://repos.fedorapeople.org/' \
-    "repos/openstack/openstack-#{node['openstack']['release']}/epel-6"
+    "repos/openstack/EOL/openstack-#{node['openstack']['release']}/epel-6"
   node.default['openstack']['yum']['repo-key'] = 'https://github.com/' \
     "redhat-openstack/rdo-release/raw/#{node['openstack']['release']}/" \
     "RPM-GPG-KEY-RDO-#{node['openstack']['release'].capitalize}"


### PR DESCRIPTION
They moved all EOL'd versions to a different repo URL. This fixes that.