### PR TITLE
Increase disk_allocation_ratio to 1.5 to allow for overcommit

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,6 +40,7 @@ node.default['openstack']['compute']['conf'].tap do |conf|
   conf['DEFAULT']['instance_usage_audit'] = 'True'
   conf['DEFAULT']['instance_usage_audit_period'] = 'hour'
   conf['DEFAULT']['notify_on_state_change'] = 'vm_and_task_state'
+  conf['DEFAULT']['disk_allocation_ratio'] = 1.5
 end
 node.default['openstack']['network'].tap do |conf|
   conf['conf']['DEFAULT']['service_plugins'] =

--- a/spec/compute_controller_spec.rb
+++ b/spec/compute_controller_spec.rb
@@ -37,6 +37,7 @@ describe 'osl-openstack::compute_controller', compute_controller: true do
       /^linuxnet_interface_driver = \
 nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver$/,
       /^dns_server = 140.211.166.130 140.211.166.131$/,
+      /^disk_allocation_ratio = 1.5$/,
       /^instance_usage_audit = True$/,
       /^instance_usage_audit_period = hour$/,
       /^notify_on_state_change = vm_and_task_state$/,

--- a/test/integration/compute_controller/serverspec/compute_controller_spec.rb
+++ b/test/integration/compute_controller/serverspec/compute_controller_spec.rb
@@ -27,6 +27,7 @@ end
   'linuxnet_interface_driver = ' \
   'nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver',
   'dns_server = 140.211.166.130 140.211.166.131',
+  'disk_allocation_ratio = 1.5',
   'instance_usage_audit = True',
   'instance_usage_audit_period = hour',
   'notify_on_state_change = vm_and_task_state'


### PR DESCRIPTION
Right now its set to 1.0 which is sub optimal given the use case for our
clusters. This allows for 50% over commitment of disk space for ephemeral uses.