### PR TITLE
Add support for per-host interfaces for vxlan and provider networks.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -76,8 +76,10 @@ suites:
         physical_interface_mappings:
           -
            name: public
-           controller: eth1
-           compute: eth1
+           controller:
+            default: eth1
+           compute:
+            default: eth1
   - name: compute_controller
     run_list:
       - role[openstack_tk]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,8 +29,12 @@ default['osl-openstack']['endpoint_hostname'] = nil
 default['osl-openstack']['db_hostname'] = nil
 default['osl-openstack']['physical_interface_mappings'] = []
 default['osl-openstack']['vxlan_interface'] = {
-  'controller' => 'eth0',
-  'compute' => 'eth0'
+  'controller' => {
+    'default' => 'eth0'
+  },
+  'compute' => {
+    'default' => 'eth0'
+  }
 }
 default['osl-openstack']['node_type'] = 'compute'
 default['osl-openstack']['nova_ssl_dir'] = '/etc/nova/pki'

--- a/recipes/linuxbridge.rb
+++ b/recipes/linuxbridge.rb
@@ -22,7 +22,12 @@ include_recipe 'openstack-network'
 node_type = node['osl-openstack']['node_type']
 int_mappings = []
 node['osl-openstack']['physical_interface_mappings'].each do |int|
-  int_mappings.push("#{int['name']}:#{int[node_type]}")
+  interface = if int[node_type][node['fqdn']]
+                int[node_type][node['fqdn']]
+              else
+                int[node_type]['default']
+              end
+  int_mappings.push("#{int['name']}:#{interface}")
 end
 
 # Get the IP for the interface we're using VXLAN for

--- a/recipes/linuxbridge.rb
+++ b/recipes/linuxbridge.rb
@@ -26,7 +26,12 @@ node['osl-openstack']['physical_interface_mappings'].each do |int|
 end
 
 # Get the IP for the interface we're using VXLAN for
-vxlan_interface = node['osl-openstack']['vxlan_interface'][node_type]
+vxlan = node['osl-openstack']['vxlan_interface']
+vxlan_interface = if vxlan[node_type][node['fqdn']]
+                    vxlan[node_type][node['fqdn']]
+                  else
+                    vxlan[node_type]['default']
+                  end
 vxlan_addrs = node['network']['interfaces'][vxlan_interface]
 vxlan_ip = if vxlan_addrs.nil?
              # Fall back to localhost if the interface has no IP

--- a/spec/linuxbridge_spec.rb
+++ b/spec/linuxbridge_spec.rb
@@ -55,12 +55,13 @@ neutron.agent.linux.iptables_firewall.IptablesFirewallDriver$/
           .with_section_content('vxlan', line)
       end
     end
-    context 'Setting controller vxlan_interface to eth1' do
+    context 'Setting controller vxlan_interface to eth0 on controller' do
       cached(:chef_run) { runner.converge(described_recipe) }
       before do
         node.set['osl-openstack']['node_type'] = 'controller'
-        node.set['osl-openstack']['vxlan_interface']['controller'] = 'eth1'
-        node.automatic['network']['interfaces']['eth1']['addresses'] = {
+        node.set['osl-openstack']['vxlan_interface']['controller'] \
+          ['default'] = 'eth0'
+        node.automatic['network']['interfaces']['eth0']['addresses'] = {
           '192.168.1.10' => {
             'family' => 'inet'
           }
@@ -78,7 +79,8 @@ neutron.agent.linux.iptables_firewall.IptablesFirewallDriver$/
       cached(:chef_run) { runner.converge(described_recipe) }
       before do
         node.set['osl-openstack']['node_type'] = 'controller'
-        node.set['osl-openstack']['vxlan_interface']['controller'] = 'eth2'
+        node.set['osl-openstack']['vxlan_interface']['controller'] \
+          ['default'] = 'eth2'
         node.automatic['network']['interfaces']['eth1']['addresses'] = {}
       end
       it do
@@ -86,6 +88,45 @@ neutron.agent.linux.iptables_firewall.IptablesFirewallDriver$/
           .with_section_content(
             'vxlan',
             /^local_ip = 127.0.0.1$/
+          )
+      end
+    end
+    context 'Setting controller vxlan_interface to eth0 on compute' do
+      cached(:chef_run) { runner.converge(described_recipe) }
+      before do
+        node.set['osl-openstack']['node_type'] = 'compute'
+        node.automatic['network']['interfaces']['eth0']['addresses'] = {
+          '192.168.1.10' => {
+            'family' => 'inet'
+          }
+        }
+      end
+      it do
+        expect(chef_run).to render_config_file(file.name)
+          .with_section_content(
+            'vxlan',
+            /^local_ip = 192.168.1.10$/
+          )
+      end
+    end
+    context 'Setting controller vxlan_interface to eth8 on compute w/ fqdn' do
+      cached(:chef_run) { runner.converge(described_recipe) }
+      before do
+        node.set['osl-openstack']['node_type'] = 'compute'
+        node.set['osl-openstack']['vxlan_interface']['compute'] \
+          ['foo.example.org'] = 'eth8'
+        node.automatic['fqdn'] = 'foo.example.org'
+        node.automatic['network']['interfaces']['eth8']['addresses'] = {
+          '192.168.1.10' => {
+            'family' => 'inet'
+          }
+        }
+      end
+      it do
+        expect(chef_run).to render_config_file(file.name)
+          .with_section_content(
+            'vxlan',
+            /^local_ip = 192.168.1.10$/
           )
       end
     end

--- a/spec/linuxbridge_spec.rb
+++ b/spec/linuxbridge_spec.rb
@@ -184,18 +184,83 @@ neutron.agent.linux.iptables_firewall.IptablesFirewallDriver$/
           [
             {
               name: 'public',
-              controller: 'eth1',
-              compute: 'eth1'
+              controller: {
+                default: 'eth1'
+              },
+              compute: {
+                default: 'eth1'
+              }
             },
             {
               name: 'private',
-              controller: 'eth2',
-              compute: 'eth2'
+              controller: {
+                default: 'eth2'
+              },
+              compute: {
+                default: 'eth2'
+              }
             }
           ]
       end
       [
         /^physical_interface_mappings = public:eth1,private:eth2$/
+      ].each do |line|
+        it do
+          expect(chef_run).to render_config_file(file.name)
+            .with_section_content('linux_bridge', line)
+        end
+      end
+    end
+    context 'Create a public:eth3 w/ different nics' do
+      cached(:chef_run) { runner.converge(described_recipe) }
+      before do
+        node.automatic['fqdn'] = 'bar.example.org'
+        node.set['osl-openstack']['physical_interface_mappings'] =
+          [
+            {
+              name: 'public',
+              controller: {
+                'default' => 'eth1',
+                'foo.example.org' => 'eth2'
+              },
+              compute: {
+                'default' => 'eth1',
+                'bar.example.org' => 'eth3'
+              }
+            }
+          ]
+      end
+      [
+        /^physical_interface_mappings = public:eth3$/
+      ].each do |line|
+        it do
+          expect(chef_run).to render_config_file(file.name)
+            .with_section_content('linux_bridge', line)
+        end
+      end
+    end
+    context 'Create a public:eth2 w/ different nics on controller' do
+      cached(:chef_run) { runner.converge(described_recipe) }
+      before do
+        node.automatic['fqdn'] = 'foo.example.org'
+        node.set['osl-openstack']['node_type'] = 'controller'
+        node.set['osl-openstack']['physical_interface_mappings'] =
+          [
+            {
+              name: 'public',
+              controller: {
+                'default' => 'eth1',
+                'foo.example.org' => 'eth2'
+              },
+              compute: {
+                'default' => 'eth1',
+                'bar.example.org' => 'eth3'
+              }
+            }
+          ]
+      end
+      [
+        /^physical_interface_mappings = public:eth2$/
       ].each do |line|
         it do
           expect(chef_run).to render_config_file(file.name)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,8 +23,12 @@ shared_context 'linuxbridge_stubs' do
     node.set['osl-openstack']['physical_interface_mappings'] =
       [
         name: 'public',
-        controller: 'eth2',
-        compute: 'eth1'
+        controller: {
+          default: 'eth2'
+        },
+        compute: {
+          default: 'eth1'
+        }
       ]
   end
 end

--- a/test/integration/roles/openstack_provisioning.json
+++ b/test/integration/roles/openstack_provisioning.json
@@ -42,8 +42,12 @@
       "physical_interface_mappings": [
         {
           "name": "public",
-          "controller": "eth0",
-          "compute": "eth0"
+          "controller": {
+            "default": "eth0"
+          },
+          "compute": {
+            "default": "eth0"
+          }
         }
       ]
     }

--- a/test/integration/roles/vagrant_provisioning.json
+++ b/test/integration/roles/vagrant_provisioning.json
@@ -44,8 +44,12 @@
       "physical_interface_mappings": [
         {
           "name": "public",
-          "controller": "enp0s8",
-          "compute": "enp0s8"
+          "controller": {
+            "default": "enp0s8"
+          },
+          "compute": {
+            "default": "enp0s8"
+          }
         }
       ]
     }


### PR DESCRIPTION
This is to deal with slight hardware differences on the OpenPOWER machines where the interface names don't exactly match up. The idea here is to set a default that works for most, and set a host specific one if it needs it.