### PR TITLE
Adjust nagios check for cinder services

### DIFF
--- a/attributes/mon.rb
+++ b/attributes/mon.rb
@@ -17,6 +17,6 @@ default['osl-openstack']['mon']['check_neutron_agents'] = {
   'critical' => '4:'
 }
 default['osl-openstack']['mon']['check_cinder_services'] = {
-  'warning' => '3:',
-  'critical' => '2:'
+  'warning' => '2:',
+  'critical' => '1:'
 }

--- a/spec/mon_spec.rb
+++ b/spec/mon_spec.rb
@@ -96,8 +96,8 @@ describe 'osl-openstack::mon' do
       expect(chef_run).to add_nrpe_check('check_cinder_services')
         .with(
           command: '/bin/sudo ' + check_openstack + ' check_cinder-services',
-          warning_condition: '3:',
-          critical_condition: '2:'
+          warning_condition: '2:',
+          critical_condition: '1:'
         )
     end
     it do

--- a/test/integration/mon_controller/serverspec/mon_controller_spec.rb
+++ b/test/integration/mon_controller/serverspec/mon_controller_spec.rb
@@ -51,7 +51,7 @@ end
 describe file('/etc/nagios/nrpe.d/check_cinder_services.cfg') do
   its(:content) do
     should match(%r{command\[check_cinder_services\]=/bin/sudo \
-/usr/lib64/nagios/plugins/check_openstack check_cinder-services -w 3: -c 2:})
+/usr/lib64/nagios/plugins/check_openstack check_cinder-services -w 2: -c 1:})
   end
 end
 


### PR DESCRIPTION
This assumes we have at least the cinder-scheduler service and one cinder-volume
service. The previous example was tested on a two node cluster so the math was
off by one.