### PR TITLE
Bump default_api_return_limit to see more meters

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -104,6 +104,7 @@ end
 
 node.default['openstack']['telemetry']['conf'].tap do |conf|
   conf['DEFAULT']['meter_dispatchers'] = 'database'
+  conf['api']['default_api_return_limit'] = 1_000_000_000_000
 end
 
 node.default['openstack']['block-storage']['conf'].tap do |conf|

--- a/spec/telemetry_spec.rb
+++ b/spec/telemetry_spec.rb
@@ -41,12 +41,14 @@ describe 'osl-openstack::telemetry', telemetry: true do
           %r{^auth_url = https://10.0.0.10:5000/v2.0$}
         )
     end
-    it do
-      expect(chef_run).to render_config_file(file.name)
-        .with_section_content(
-          'api',
-          /^host = 10.0.0.2$/
-        )
+    [
+      /^host = 10.0.0.2$/,
+      /^default_api_return_limit = 1000000000000$/
+    ].each do |line|
+      it do
+        expect(chef_run).to render_config_file(file.name)
+          .with_section_content('api', line)
+      end
     end
     it do
       expect(chef_run).to render_config_file(file.name)

--- a/test/integration/telemetry/serverspec/telemetry_spec.rb
+++ b/test/integration/telemetry/serverspec/telemetry_spec.rb
@@ -41,6 +41,15 @@ end
   end
 end
 
+[
+  /^host = (?:[0-9]{1,3}\.){3}[0-9]{1,3}$/,
+  /^default_api_return_limit = 1000000000000$/
+].each do |s|
+  describe file('/etc/ceilometer/ceilometer.conf') do
+    its(:content) { should contain(/#{s}/).after(/^\[api\]/) }
+  end
+end
+
 describe command('source /root/openrc && ceilometer meter-list') do
   its(:stdout) { should contain(/Project ID/) }
   its(:stdout) { should_not contain(/Gone (HTTP 410) /) }


### PR DESCRIPTION
By default, ceilometer limits the amount of meters to list to 100, but when you
are checking a lot of meters, this means you don't see all of the meters. As a
workaround [1], it's suggested to bump that amount to something really high. The
unfortunate side affect is that the resources dashboard will take a while to run
depending on how much data you have, but at least you can see the meters.

This partially fixes issues described in #55.

[1] https://bugs.launchpad.net/ceilometer/+bug/1540204