### PR TITLE
Use the package qemu-img-ev as the preferred package name

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -113,6 +113,8 @@ node.default['openstack']['block-storage']['conf'].tap do |conf|
   conf['DEFAULT']['volume_clear_size'] = 256
 end
 
+node.default['openstack']['block-storage']['platform']['cinder_volume_packages'] = %w(qemu-img-ev)
+
 # Dynamically find the hostname for the controller node, or use a pre-determined
 # DNS name
 if node['osl-openstack']['endpoint_hostname'].nil?

--- a/spec/block_storage_spec.rb
+++ b/spec/block_storage_spec.rb
@@ -29,6 +29,9 @@ describe 'osl-openstack::block_storage', block_storage: true do
     stub_search(:node, 'role:iscsi_role')
       .and_return([{ ipaddress: '10.10.0.1' }])
   end
+  it do
+    expect(chef_run).to upgrade_package('qemu-img-ev')
+  end
   it 'adds iscsi nodes ipaddresses' do
     # TODO: Add a test that actually works with the node search
     expect(chef_run).to create_iptables_ng_rule('iscsi_ipv4').with(


### PR DESCRIPTION
Without this, it tries to install qemu-img which has been excluded from the
upstream repos in favor of RHEV.