### PR TITLE
Including ibm-power as a dependency

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -11,6 +11,7 @@ cookbook 'resource_from_hash',
          git: 'git@github.com:osuosl-cookbooks/resource_from_hash'
 cookbook 'statsd', github: 'att-cloud/cookbook-statsd'
 cookbook 'yum-qemu-ev', git: 'git@github.com:osuosl-cookbooks/yum-qemu-ev.git'
+cookbook 'ibm-power', git: 'git@github.com:osuosl-cookbooks/ibm-power.git'
 
 # WIP patches
 # %w(

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ version          '2.3.2'
   openstack-dashboard openstack-identity openstack-integration-test
   openstack-image openstack-network openstack-ops-database
   openstack-ops-messaging openstack-orchestration openstack-telemetry selinux
-  sudo yum-qemu-ev}.each do |cb|
+  sudo yum-qemu-ev ibm-power}.each do |cb|
   depends cb
 end
 

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -20,6 +20,7 @@ include_recipe 'firewall'
 include_recipe 'firewall::openstack'
 include_recipe 'firewall::vnc'
 include_recipe 'osl-openstack::default'
+include_recipe 'ibm-power::default'
 
 kernel_module 'tun'
 

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -27,6 +27,7 @@ describe 'osl-openstack::compute', compute: true do
     osl-openstack::linuxbridge
     openstack-compute::compute
     openstack-telemetry::agent-compute
+    ibm-power::default
   ).each do |r|
     it "includes cookbook #{r}" do
       expect(chef_run).to include_recipe(r)


### PR DESCRIPTION
To fix the `execute[ppc64_cpu_smt_off]`resource convergence failure on this cookbook.
`ibm-power` recipe does the thing described at http://wiki.osuosl.org/openpower/openstack.html#turn-off-smt