### PR TITLE
Update the nrpe_check[check_load] resource instead of trying to override attrs

### DIFF
--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -20,10 +20,9 @@
 # Increase load threshold on openpower nodes (double the default values)
 if %w(ppc64 ppc64le).include?(node['kernel']['machine'])
   total_cpu = node['cpu']['total']
-  node.default['osl-nrpe']['check_load'] = {
-    'warning' => "#{total_cpu * 4 + 10},#{total_cpu * 4 + 5},#{total_cpu * 4}",
-    'critical' => "#{total_cpu * 8 + 10},#{total_cpu * 8 + 5},#{total_cpu * 8}"
-  }
+  r = resources(nrpe_check: 'check_load')
+  r.warning_condition = "#{total_cpu * 4 + 10},#{total_cpu * 4 + 5},#{total_cpu * 4}"
+  r.critical_condition = "#{total_cpu * 8 + 10},#{total_cpu * 8 + 5},#{total_cpu * 8}"
 end
 
 include_recipe 'osl-nrpe'

--- a/spec/mon_spec.rb
+++ b/spec/mon_spec.rb
@@ -15,17 +15,14 @@ describe 'osl-openstack::mon' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
           node.automatic['kernel']['machine'] = a
-        end.converge(described_recipe)
+        end.converge('osl-nrpe', described_recipe)
       end
-      it 'sets check_load warning attributes correctly' do
+      it do
         total_cpu = chef_run.node['cpu']['total']
-        expect(chef_run.node['osl-nrpe']['check_load']['warning']).to \
-          eq("#{total_cpu * 4 + 10},#{total_cpu * 4 + 5},#{total_cpu * 4}")
-      end
-      it 'sets check_load critical attributes correctly' do
-        total_cpu = chef_run.node['cpu']['total']
-        expect(chef_run.node['osl-nrpe']['check_load']['critical']).to \
-          eq("#{total_cpu * 8 + 10},#{total_cpu * 8 + 5},#{total_cpu * 8}")
+        expect(chef_run).to add_nrpe_check('check_load').with(
+          warning_condition: "#{total_cpu * 4 + 10},#{total_cpu * 4 + 5},#{total_cpu * 4}",
+          critical_condition: "#{total_cpu * 8 + 10},#{total_cpu * 8 + 5},#{total_cpu * 8}"
+        )
       end
     end
   end


### PR DESCRIPTION
The current logic is broken in production due to attribute precedence. The
ChefSpec tests didn't catch it due to the fact that osl-nrpe wasn't included in
the converge run list. By adding it, this replicates what happens in production
and verifies this works correctly finally. I also verfied this new test fails on
the old code.

@jldugger @knightsamar I'd like to push this fix through and see how it adjusts our load alerts. It looks like this code wasn't working originally as intended.