### PR TITLE
diff package name for qemu-img-ev on ppc64le

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -113,7 +113,12 @@ node.default['openstack']['block-storage']['conf'].tap do |conf|
   conf['DEFAULT']['volume_clear_size'] = 256
 end
 
-node.default['openstack']['block-storage']['platform']['cinder_volume_packages'] = %w(qemu-img-ev)
+case node['kernel']['machine']
+when 'ppc64', 'ppc64le'
+  node.default['openstack']['block-storage']['platform']['cinder_volume_packages'] = %w(qemu-img-rhev)
+when 'x86_64'
+  node.default['openstack']['block-storage']['platform']['cinder_volume_packages'] = %w(qemu-img-ev)
+end
 
 # Dynamically find the hostname for the controller node, or use a pre-determined
 # DNS name

--- a/spec/block_storage_spec.rb
+++ b/spec/block_storage_spec.rb
@@ -29,9 +29,27 @@ describe 'osl-openstack::block_storage', block_storage: true do
     stub_search(:node, 'role:iscsi_role')
       .and_return([{ ipaddress: '10.10.0.1' }])
   end
-  it do
-    expect(chef_run).to upgrade_package('qemu-img-ev')
+
+  context 'setting arch to x86_64' do
+    before do
+      node.automatic['kernel']['machine'] = 'x86_64'
+    end
+    it 'uses the right package name for qemu-img-ev on x86_64 arch' do
+      expect(chef_run).to upgrade_package('qemu-img-ev')
+    end
   end
+  %w(ppc64 ppc64le).each do |a|
+    context "setting arch to #{a}" do
+      let(:chef_run) { runner.converge(described_recipe) }
+      before do
+        node.automatic['kernel']['machine'] = a
+      end
+      it 'uses the right package name for qemu-img-ev on #{a} arch' do
+        expect(chef_run).to upgrade_package('qemu-img-rhev')
+      end
+    end
+  end
+
   it 'adds iscsi nodes ipaddresses' do
     # TODO: Add a test that actually works with the node search
     expect(chef_run).to create_iptables_ng_rule('iscsi_ipv4').with(


### PR DESCRIPTION
It has changed for centos 7.3 on ppc64le from `qemu-img-ev` to `qemu-img-rhev`

About tests:
* I could not figure out how exactly to test a node attribute in ChefSpec.
* Should the ServerSpec go in default or should we have something upstream instead of this commit here?