### PR TITLE
Bump check-load warning threshold a little higher

### DIFF
--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -21,7 +21,7 @@
 if %w(ppc64 ppc64le).include?(node['kernel']['machine'])
   total_cpu = node['cpu']['total']
   r = resources(nrpe_check: 'check_load')
-  r.warning_condition = "#{total_cpu * 4 + 10},#{total_cpu * 4 + 5},#{total_cpu * 4}"
+  r.warning_condition = "#{total_cpu * 5 + 10},#{total_cpu * 5 + 5},#{total_cpu * 5}"
   r.critical_condition = "#{total_cpu * 8 + 10},#{total_cpu * 8 + 5},#{total_cpu * 8}"
 end
 

--- a/spec/mon_spec.rb
+++ b/spec/mon_spec.rb
@@ -20,7 +20,7 @@ describe 'osl-openstack::mon' do
       it do
         total_cpu = chef_run.node['cpu']['total']
         expect(chef_run).to add_nrpe_check('check_load').with(
-          warning_condition: "#{total_cpu * 4 + 10},#{total_cpu * 4 + 5},#{total_cpu * 4}",
+          warning_condition: "#{total_cpu * 5 + 10},#{total_cpu * 5 + 5},#{total_cpu * 5}",
           critical_condition: "#{total_cpu * 8 + 10},#{total_cpu * 8 + 5},#{total_cpu * 8}"
         )
       end

--- a/test/integration/mon/serverspec/mon_spec.rb
+++ b/test/integration/mon/serverspec/mon_spec.rb
@@ -6,7 +6,7 @@ set :backend, :exec
 t_cpu = 4
 
 load_thres = if %w(ppc64 ppc64le).include?(os[:arch])
-               "-w #{t_cpu * 4 + 10},#{t_cpu * 4 + 5},#{t_cpu * 4} " \
+               "-w #{t_cpu * 5 + 10},#{t_cpu * 5 + 5},#{t_cpu * 5} " \
                "-c #{t_cpu * 8 + 10},#{t_cpu * 8 + 5},#{t_cpu * 8}"
              else
                "-w #{t_cpu * 2 + 10},#{t_cpu * 2 + 5},#{t_cpu * 2} " \


### PR DESCRIPTION
This seems to be a value that shouldn't trigger under normal load.