### PR TITLE
Restart linuxbridge-agent when iptable rules are updated

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,10 +19,6 @@
 
 node.default['authorization']['sudo']['include_sudoers_d'] = true
 node.default['apache']['contact'] = 'hostmaster@osuosl.org'
-node.default['firewall']['iptables-config'].tap do |conf|
-  conf['save_on_restart'] = 'yes'
-  conf['save_on_stop'] = 'yes'
-end
 node.default['yum']['qemu-ev-attr']['glusterfs_34'] = true
 node.default['rabbitmq']['use_distro_version'] = true
 node.default['openstack']['release'] = 'mitaka'

--- a/recipes/linuxbridge.rb
+++ b/recipes/linuxbridge.rb
@@ -54,3 +54,9 @@ node.default['openstack']['network']['plugins']['linuxbridge']['conf']
 end
 
 include_recipe 'openstack-network::ml2_linuxbridge'
+
+# When iptables-ng creates new rules, restart linuxbridge-agent so that it generates the iptables rules after iptables
+# is restarted.
+edit_resource(:service, 'neutron-plugin-linuxbridge-agent') do
+  subscribes :restart, 'ruby_block[create_rules]'
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -37,18 +37,6 @@ describe 'osl-openstack::default', default: true do
       end
     end
   end
-  describe '/etc/sysconfig/iptables-config' do
-    let(:file) { chef_run.template('/etc/sysconfig/iptables-config') }
-    [
-      /^IPTABLES_SAVE_ON_STOP="yes"$/,
-      /^IPTABLES_SAVE_ON_RESTART="yes"$/
-    ].each do |line|
-      it do
-        expect(chef_run).to render_config_file(file.name)
-          .with_content(line)
-      end
-    end
-  end
   cached(:chef_run) { runner.converge(described_recipe) }
   %w(
     base::ifconfig

--- a/spec/linuxbridge_spec.rb
+++ b/spec/linuxbridge_spec.rb
@@ -269,4 +269,7 @@ neutron.agent.linux.iptables_firewall.IptablesFirewallDriver$/
       end
     end
   end
+  it do
+    expect(chef_run.service('neutron-plugin-linuxbridge-agent')).to subscribe_to('ruby_block[create_rules]')
+  end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -21,8 +21,3 @@ end
 describe file('/root/openrc') do
   its(:content) { should_not match(%r{OS_AUTH_URL=http://127.0.0.1/v2.0}) }
 end
-
-describe file('/etc/sysconfig/iptables-config') do
-  its(:content) { should match(/^IPTABLES_SAVE_ON_STOP="yes"$/) }
-  its(:content) { should match(/^IPTABLES_SAVE_ON_RESTART="yes"$/) }
-end


### PR DESCRIPTION
This works around an issue where the current setup will not apply new iptables
rules due to the that the rules are saved. Instead, use iptables like we do
elsewhere, only also restart linuxbridge-agent if rule are updated. That way
those rules are generated again.

NOTE: all references to ``node['firewall']['iptables-config'`` will also need to be removed from the openstack roles as they are added there too.