### PR TITLE
Restart linuxbridge-agent when iptable rules are updated

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ version          '2.3.6'
   openstack-dashboard openstack-identity openstack-integration-test
   openstack-image openstack-network openstack-ops-database
   openstack-ops-messaging openstack-orchestration openstack-telemetry selinux
-  sudo yum-qemu-ev ibm-power}.each do |cb|
+  sudo systemd yum-qemu-ev ibm-power}.each do |cb|
   depends cb
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,10 +19,6 @@
 
 node.default['authorization']['sudo']['include_sudoers_d'] = true
 node.default['apache']['contact'] = 'hostmaster@osuosl.org'
-node.default['firewall']['iptables-config'].tap do |conf|
-  conf['save_on_restart'] = 'yes'
-  conf['save_on_stop'] = 'yes'
-end
 node.default['yum']['qemu-ev-attr']['glusterfs_34'] = true
 node.default['rabbitmq']['use_distro_version'] = true
 node.default['openstack']['release'] = 'mitaka'

--- a/recipes/linuxbridge.rb
+++ b/recipes/linuxbridge.rb
@@ -54,3 +54,9 @@ node.default['openstack']['network']['plugins']['linuxbridge']['conf']
 end
 
 include_recipe 'openstack-network::ml2_linuxbridge'
+
+systemd_service node['openstack']['network']['platform']['neutron_linuxbridge_agent_service'] do
+  part_of "#{node['iptables-ng']['service_ipv4']}.service"
+  override node['openstack']['network']['platform']['neutron_linuxbridge_agent_service']
+  drop_in true
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -37,18 +37,6 @@ describe 'osl-openstack::default', default: true do
       end
     end
   end
-  describe '/etc/sysconfig/iptables-config' do
-    let(:file) { chef_run.template('/etc/sysconfig/iptables-config') }
-    [
-      /^IPTABLES_SAVE_ON_STOP="yes"$/,
-      /^IPTABLES_SAVE_ON_RESTART="yes"$/
-    ].each do |line|
-      it do
-        expect(chef_run).to render_config_file(file.name)
-          .with_content(line)
-      end
-    end
-  end
   cached(:chef_run) { runner.converge(described_recipe) }
   %w(
     base::ifconfig

--- a/spec/linuxbridge_spec.rb
+++ b/spec/linuxbridge_spec.rb
@@ -269,4 +269,12 @@ neutron.agent.linux.iptables_firewall.IptablesFirewallDriver$/
       end
     end
   end
+  it do
+    expect(chef_run).to create_systemd_service('neutron-linuxbridge-agent')
+      .with(
+        part_of: 'iptables.service',
+        override: 'neutron-linuxbridge-agent',
+        drop_in: true
+      )
+  end
 end

--- a/test/integration/linuxbridge/serverspec/linuxbridge_spec.rb
+++ b/test/integration/linuxbridge/serverspec/linuxbridge_spec.rb
@@ -39,3 +39,7 @@ neutron.agent.linux.iptables_firewall.IptablesFirewallDriver/)
       .after(/^\[securitygroup\]/)
   end
 end
+
+describe command('systemctl list-dependencies --reverse neutron-linuxbridge-agent') do
+  its(:stdout) { should contain(/iptables/) }
+end


### PR DESCRIPTION
This works around an issue where the current setup will not apply new iptables
rules due to the that the rules are saved. Instead, use iptables like we do
elsewhere, only also restart linuxbridge-agent if rule are updated. That way
those rules are generated again. This removes the save settings in the iptables
init script so that the rules are cleared on every restart.

This uses a systemd override using PartOf which ties linuxbridge-agent to
iptable restarts. Whenever iptables is restarted, linuxbridge-agent is now also
restarted which should fill the rules that are needed properly.

IMO, this is a better solution that I proposed in #69. 