### PR TITLE
Only restart keystone apache on an initial install

### DIFF
--- a/recipes/identity.rb
+++ b/recipes/identity.rb
@@ -22,3 +22,10 @@ include_recipe 'firewall::openstack'
 include_recipe 'certificate::wildcard'
 include_recipe 'openstack-identity::server-apache'
 include_recipe 'openstack-identity::registration'
+
+# Only restart Keystone apache during the initial install. This causes monitoring and service issues while the service
+# is restarted.
+edit_resource(:execute, 'Keystone apache restart') do
+  command "touch #{Chef::Config[:file_cache_path]}/keystone-apache-restarted"
+  creates "#{Chef::Config[:file_cache_path]}/keystone-apache-restarted"
+end

--- a/spec/identity_spec.rb
+++ b/spec/identity_spec.rb
@@ -93,4 +93,11 @@ describe 'osl-openstack::identity', identity: true do
       end
     end
   end
+  it do
+    expect(chef_run).to run_execute('Keystone apache restart')
+      .with(
+        command: "touch #{Chef::Config[:file_cache_path]}/keystone-apache-restarted",
+        creates: "#{Chef::Config[:file_cache_path]}/keystone-apache-restarted"
+      )
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ ChefSpec::Coverage.start! { add_filter 'osl-openstack' }
 REDHAT_OPTS = {
   platform: 'centos',
   version: '7.2.1511',
+  file_cache_path: '/var/chef/cache',
   log_level: :fatal
 }.freeze
 


### PR DESCRIPTION
This override the upstream resource to create a file that gets touched after the
first run. After that, it won't notify the apache2 service anymore. This should
stop the constant restart of apache on every chef run on the controller.