### PR TITLE
Install and setup the Mellanox NEO service

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -124,6 +124,13 @@ suites:
       - role[openstack_tk]
       - role[openstack_ops_identity]
       - recipe[osl-openstack::telemetry]
+  - name: mellanox_neo
+    attributes:
+      osl-openstack:
+        mellanox_neo:
+          server_hostname: 'neo.osuosl.org'
+    run_list:
+      - recipe[osl-openstack::mellanox_neo]
   - name: controller
     run_list:
       - role[openstack_tk]

--- a/attributes/mellanox_neo.rb
+++ b/attributes/mellanox_neo.rb
@@ -13,16 +13,107 @@ default['osl-openstack']['mellanox_neo']['packages'] = %w(
   neo-provider-solution
   neo-provider-virtualization
 )
-default['osl-openstack']['mellanox_neo']['services'] = %w(
-  neo-access-credentials
-  neo-controller
-  neo-device-manager
-  neo-eth-discovery
-  neo-ib
-  neo-ip-discovery
-  neo-monitor
-  neo-performance
-  neo-provisioning
-  neo-solution
-  neo-virtualization
-)
+default['osl-openstack']['mellanox_neo']['services'] = {
+  'neo-access-credentials' => {
+    'python_path' => %w(
+      /opt/neo/providers/ac/bin
+      /opt/neo/common/bin
+      /opt/neo/providers/common/bin
+    ),
+    'port_check_config' => '/opt/neo/files/providers/ac/conf/netservice.cfg',
+    'start_bin' => '/opt/neo/providers/ac/bin/ac/ac_service.pyo'
+  },
+  'neo-controller' => {
+    'python_path' => %w(
+      /opt/neo/controller/bin
+      /opt/neo/common/bin
+    ),
+    'port_check_config' => '/opt/neo/files/controller/conf/controller.cfg --exclude-patterns Protocol::[\w]+',
+    'start_bin' => '/opt/neo/controller/bin/controller/sdn_controller.pyo'
+  },
+  'neo-device-manager' => {
+    'python_path' => %w(
+      /opt/neo/providers/dm/bin
+      /opt/neo/common/bin
+      /opt/neo/providers/common/bin
+    ),
+    'port_check_config' => '/opt/neo/files/providers/dm/conf/netservice.cfg',
+    'start_bin' => '/opt/neo/providers/dm/bin/dm/dm_service.pyo'
+  },
+  'neo-eth-discovery' => {
+    'python_path' => %w(
+      /opt/neo/providers/ethdisc/bin
+      /opt/neo/common/bin
+      /opt/neo/providers/common/bin
+    ),
+    'port_check_config' => '/opt/neo/files/providers/ethdisc/conf/netservice.cfg',
+    'start_bin' => '/opt/neo/providers/ethdisc/bin/ethdisc/eth_discovery_service.pyo'
+  },
+  'neo-ib' => {
+    'python_path' => %w(
+      /opt/neo/providers/ib/bin
+      /opt/neo/common/bin
+      /opt/neo/providers/common/bin
+    ),
+    'port_check_config' => '/opt/neo/files/providers/ib/conf/netservice.cfg',
+    'start_bin' => '/opt/neo/providers/ib/bin/ib/ib_service.pyo'
+  },
+  'neo-ip-discovery' => {
+    'python_path' => %w(
+      /opt/neo/providers/discovery/bin
+      /opt/neo/common/bin
+      /opt/neo/providers/common/bin
+    ),
+    'port_check_config' => '/opt/neo/files/providers/discovery/conf/netservice.cfg',
+    'start_bin' => '/opt/neo/providers/discovery/bin/discovery/ip_discovery_service.pyo'
+  },
+  'neo-monitor' => {
+    'python_path' => %w(
+      /opt/neo/providers/monitor/bin
+      /opt/neo/common/bin
+      /opt/neo/providers/common/bin
+    ),
+    'port_check_config' => '/opt/neo/files/providers/monitor/conf/netservice.cfg',
+    'start_bin' => '/opt/neo/providers/monitor/bin/monitor/monitor_service.pyo'
+  },
+  'neo-performance' => {
+    'python_path' => %w(
+      /opt/neo/providers/performance/bin
+      /opt/neo/common/bin
+      /opt/neo/providers/common/bin
+      /opt/neo/tools/src
+    ),
+    'port_check_config' => '/opt/neo/files/providers/performance/conf/netservice.cfg',
+    'start_bin' => '/opt/neo/providers/performance/bin/performance/perf_service.pyo'
+  },
+  'neo-provisioning' => {
+    'python_path' => %w(
+      /opt/neo/providers/provisioning/bin
+      /opt/neo/common/bin
+      /opt/neo/providers/common/bin
+      /opt/neo/tools/src
+    ),
+    'port_check_config' => '/opt/neo/files/providers/provisioning/conf/netservice.cfg',
+    'start_bin' => '/opt/neo/providers/provisioning/bin/provisioning/prov_service.pyo'
+  },
+  'neo-solution' => {
+    'python_path' => %w(
+      /opt/neo/providers/solution/bin
+      /opt/neo/common/bin
+      /opt/neo/providers/common/bin
+    ),
+    'port_check_config' => '/opt/neo/files/providers/solution/conf/netservice.cfg',
+    'start_bin' => '/opt/neo/providers/solution/bin/solution/solution_service.pyo'
+  },
+  'neo-virtualization' => {
+    'python_path' => %w(
+      /opt/neo/providers/virtualization/bin
+      /opt/neo/common/bin
+      /opt/neo/providers/common/bin
+    ),
+    'port_check_config' => '/opt/neo/files/providers/virtualization/conf/netservice.cfg',
+    'start_bin' => '/opt/neo/providers/virtualization/bin/virtualization/virtualization_service.pyo'
+  }
+}
+default['osl-openstack']['mellanox_neo']['port_check_bin'] =
+  '/opt/neo/common/bin/netservices/common/utils/ports_validator.pyo'

--- a/attributes/mellanox_neo.rb
+++ b/attributes/mellanox_neo.rb
@@ -1,0 +1,28 @@
+default['osl-openstack']['mellanox_neo']['server_hostname'] = node['fqdn']
+default['osl-openstack']['mellanox_neo']['packages'] = %w(
+  neo-controller
+  neo-provider-ac
+  neo-provider-common
+  neo-provider-discovery
+  neo-provider-dm
+  neo-provider-ethdisc
+  neo-provider-ib
+  neo-provider-monitor
+  neo-provider-performance
+  neo-provider-provisioning
+  neo-provider-solution
+  neo-provider-virtualization
+)
+default['osl-openstack']['mellanox_neo']['services'] = %w(
+  neo-access-credentials
+  neo-controller
+  neo-device-manager
+  neo-eth-discovery
+  neo-ib
+  neo-ip-discovery
+  neo-monitor
+  neo-performance
+  neo-provisioning
+  neo-solution
+  neo-virtualization
+)

--- a/files/default/neo.conf
+++ b/files/default/neo.conf
@@ -1,0 +1,32 @@
+ProxyRequests Off
+ProxyPreserveHost On
+RewriteEngine On
+
+<Proxy *>
+    Require all granted
+</Proxy>
+
+RedirectMatch ^/$ /neo/
+
+<Location /neo>
+    RedirectMatch 301 ^/neo$ /neo/
+
+    ProxyPass http://127.0.0.1:5000
+    ProxyPassReverse http://127.0.0.1:5000
+
+    RequestHeader add X-Script-Name "/neo"
+    RequestHeader add X-Scheme 'http'
+    RequestHeader set X-Scheme 'https' env=HTTPS
+</Location>
+
+Redirect 307 /ufmvpi /neo
+
+<Directory "/opt/neo/controller/docs">
+    AllowOverride None
+    Options FollowSymLinks
+</Directory>
+
+<Location /neo-docs>
+</Location>
+
+alias "/neo-docs" "/opt/neo/controller/docs"

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ version          '2.3.9'
   openstack-dashboard openstack-identity openstack-integration-test
   openstack-image openstack-network openstack-ops-database
   openstack-ops-messaging openstack-orchestration openstack-telemetry selinux
-  sudo systemd yum-qemu-ev ibm-power}.each do |cb|
+  sudo systemd yum-qemu-ev ibm-power apache2 yum-epel}.each do |cb|
   depends cb
 end
 

--- a/recipes/mellanox_neo.rb
+++ b/recipes/mellanox_neo.rb
@@ -1,0 +1,61 @@
+#
+# Cookbook:: osl-openstack
+# Recipe:: mellanox_neo
+#
+# Copyright:: 2017, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_recipe 'osl-apache'
+include_recipe 'apache2::mod_ssl'
+include_recipe 'apache2::mod_proxy'
+include_recipe 'apache2::mod_proxy_http'
+include_recipe 'apache2::mod_proxy_balancer'
+include_recipe 'yum-epel'
+include_recipe 'certificate::wildcard'
+
+delete_resource(:directory, "#{node['apache']['dir']}/conf.d")
+
+package 'yum-plugin-priorities'
+
+neo = node['osl-openstack']['mellanox_neo']
+
+yum_repository 'mellanox-neo' do
+  description 'Mellanox Neo'
+  url "http://packages.osuosl.org/repositories/#{node['platform']}-$releasever/mellanox-neo"
+  gpgcheck false
+  priority '1'
+end
+
+neo['packages'].each do |p|
+  package p
+end
+
+neo['services'].each do |s|
+  service s do
+    action [:enable, :start]
+  end
+end
+
+apache_app neo['server_hostname'] do
+  directory '/opt/neo/controller/docs'
+  directive_http [
+    'RewriteCond %{HTTPS} !=on',
+    'RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]'
+  ]
+  ssl_enable true
+  cert_chain '/etc/pki/tls/certs/wildcard-bundle.crt'
+  cert_file '/etc/pki/tls/certs/wildcard.pem'
+  cert_key '/etc/pki/tls/private/wildcard.key'
+  include_config true
+  include_name 'neo'
+end

--- a/recipes/mellanox_neo.rb
+++ b/recipes/mellanox_neo.rb
@@ -40,8 +40,21 @@ neo['packages'].each do |p|
   package p
 end
 
-neo['services'].each do |s|
-  service s do
+neo['services'].each do |service, options|
+  systemd_service service do
+    description service
+    after %w(network.target)
+    install do
+      wanted_by 'multi-user.target'
+    end
+    service do
+      environment 'PYTHONPATH' => options['python_path'].join(':')
+      exec_start_pre "/usr/bin/python -O #{neo['port_check_bin']} -f #{options['port_check_config']}"
+      exec_start '/bin/python -O ' + options['start_bin']
+      pid_file "/var/run/#{service}.pid"
+    end
+  end
+  service service do
     action [:enable, :start]
   end
 end

--- a/spec/unit/recipes/mellanox_neo_spec.rb
+++ b/spec/unit/recipes/mellanox_neo_spec.rb
@@ -59,24 +59,126 @@ describe 'osl-openstack::mellanox_neo' do
     end
   end
 
-  %w(
-    neo-access-credentials
-    neo-controller
-    neo-device-manager
-    neo-eth-discovery
-    neo-ib
-    neo-ip-discovery
-    neo-monitor
-    neo-performance
-    neo-provisioning
-    neo-solution
-    neo-virtualization
-  ).each do |s|
+  {
+    'neo-access-credentials' => {
+      'python_path' => %w(
+        /opt/neo/providers/ac/bin
+        /opt/neo/common/bin
+        /opt/neo/providers/common/bin
+      ),
+      'port_check_config' => '/opt/neo/files/providers/ac/conf/netservice.cfg',
+      'start_bin' => '/opt/neo/providers/ac/bin/ac/ac_service.pyo'
+    },
+    'neo-controller' => {
+      'python_path' => %w(
+        /opt/neo/controller/bin
+        /opt/neo/common/bin
+      ),
+      'port_check_config' => '/opt/neo/files/controller/conf/controller.cfg --exclude-patterns Protocol::[\w]+',
+      'start_bin' => '/opt/neo/controller/bin/controller/sdn_controller.pyo'
+    },
+    'neo-device-manager' => {
+      'python_path' => %w(
+        /opt/neo/providers/dm/bin
+        /opt/neo/common/bin
+        /opt/neo/providers/common/bin
+      ),
+      'port_check_config' => '/opt/neo/files/providers/dm/conf/netservice.cfg',
+      'start_bin' => '/opt/neo/providers/dm/bin/dm/dm_service.pyo'
+    },
+    'neo-eth-discovery' => {
+      'python_path' => %w(
+        /opt/neo/providers/ethdisc/bin
+        /opt/neo/common/bin
+        /opt/neo/providers/common/bin
+      ),
+      'port_check_config' => '/opt/neo/files/providers/ethdisc/conf/netservice.cfg',
+      'start_bin' => '/opt/neo/providers/ethdisc/bin/ethdisc/eth_discovery_service.pyo'
+    },
+    'neo-ib' => {
+      'python_path' => %w(
+        /opt/neo/providers/ib/bin
+        /opt/neo/common/bin
+        /opt/neo/providers/common/bin
+      ),
+      'port_check_config' => '/opt/neo/files/providers/ib/conf/netservice.cfg',
+      'start_bin' => '/opt/neo/providers/ib/bin/ib/ib_service.pyo'
+    },
+    'neo-ip-discovery' => {
+      'python_path' => %w(
+        /opt/neo/providers/discovery/bin
+        /opt/neo/common/bin
+        /opt/neo/providers/common/bin
+      ),
+      'port_check_config' => '/opt/neo/files/providers/discovery/conf/netservice.cfg',
+      'start_bin' => '/opt/neo/providers/discovery/bin/discovery/ip_discovery_service.pyo'
+    },
+    'neo-monitor' => {
+      'python_path' => %w(
+        /opt/neo/providers/monitor/bin
+        /opt/neo/common/bin
+        /opt/neo/providers/common/bin
+      ),
+      'port_check_config' => '/opt/neo/files/providers/monitor/conf/netservice.cfg',
+      'start_bin' => '/opt/neo/providers/monitor/bin/monitor/monitor_service.pyo'
+    },
+    'neo-performance' => {
+      'python_path' => %w(
+        /opt/neo/providers/performance/bin
+        /opt/neo/common/bin
+        /opt/neo/providers/common/bin
+        /opt/neo/tools/src
+      ),
+      'port_check_config' => '/opt/neo/files/providers/performance/conf/netservice.cfg',
+      'start_bin' => '/opt/neo/providers/performance/bin/performance/perf_service.pyo'
+    },
+    'neo-provisioning' => {
+      'python_path' => %w(
+        /opt/neo/providers/provisioning/bin
+        /opt/neo/common/bin
+        /opt/neo/providers/common/bin
+        /opt/neo/tools/src
+      ),
+      'port_check_config' => '/opt/neo/files/providers/provisioning/conf/netservice.cfg',
+      'start_bin' => '/opt/neo/providers/provisioning/bin/provisioning/prov_service.pyo'
+    },
+    'neo-solution' => {
+      'python_path' => %w(
+        /opt/neo/providers/solution/bin
+        /opt/neo/common/bin
+        /opt/neo/providers/common/bin
+      ),
+      'port_check_config' => '/opt/neo/files/providers/solution/conf/netservice.cfg',
+      'start_bin' => '/opt/neo/providers/solution/bin/solution/solution_service.pyo'
+    },
+    'neo-virtualization' => {
+      'python_path' => %w(
+        /opt/neo/providers/virtualization/bin
+        /opt/neo/common/bin
+        /opt/neo/providers/common/bin
+      ),
+      'port_check_config' => '/opt/neo/files/providers/virtualization/conf/netservice.cfg',
+      'start_bin' => '/opt/neo/providers/virtualization/bin/virtualization/virtualization_service.pyo'
+    }
+  }.each do |service, options|
     it do
-      expect(chef_run).to enable_service(s)
+      port_check = '/opt/neo/common/bin/netservices/common/utils/ports_validator.pyo'
+      expect(chef_run).to create_systemd_service(service)
+        .with(
+          description: service,
+          after: %w(network.target),
+          wanted_by: 'multi-user.target',
+          environment: { 'PYTHONPATH' => options['python_path'].join(':') },
+          exec_start_pre: "/usr/bin/python -O #{port_check} -f #{options['port_check_config']}",
+          exec_start: '/bin/python -O ' + options['start_bin'],
+          pid_file: "/var/run/#{service}.pid"
+        )
     end
     it do
-      expect(chef_run).to start_service(s)
+      expect(chef_run).to enable_service(service)
+    end
+    it do
+      expect(chef_run).to start_service(service)
     end
   end
 

--- a/spec/unit/recipes/mellanox_neo_spec.rb
+++ b/spec/unit/recipes/mellanox_neo_spec.rb
@@ -1,0 +1,99 @@
+require_relative '../../spec_helper'
+
+describe 'osl-openstack::mellanox_neo' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(REDHAT_OPTS).converge(described_recipe)
+  end
+  before do
+    stub_command('/usr/sbin/httpd -t')
+  end
+  it 'converges successfully' do
+    expect { chef_run }.to_not raise_error
+  end
+
+  it do
+    expect(chef_run).to_not delete_directory('/etc/httpd/conf.d')
+  end
+
+  %w(
+    osl-apache
+    apache2::mod_ssl
+    apache2::mod_proxy
+    apache2::mod_proxy_http
+    apache2::mod_proxy_balancer
+    yum-epel
+    certificate::wildcard
+  ).each do |r|
+    it do
+      expect(chef_run).to include_recipe(r)
+    end
+  end
+
+  it do
+    expect(chef_run).to create_yum_repository('mellanox-neo')
+      .with(
+        description: 'Mellanox Neo',
+        url: 'http://packages.osuosl.org/repositories/centos-$releasever/mellanox-neo',
+        gpgcheck: false,
+        priority: '1'
+      )
+  end
+
+  %w(
+    yum-plugin-priorities
+    neo-controller
+    neo-provider-ac
+    neo-provider-common
+    neo-provider-discovery
+    neo-provider-dm
+    neo-provider-ethdisc
+    neo-provider-ib
+    neo-provider-monitor
+    neo-provider-performance
+    neo-provider-provisioning
+    neo-provider-solution
+    neo-provider-virtualization
+  ).each do |p|
+    it do
+      expect(chef_run).to install_package(p)
+    end
+  end
+
+  %w(
+    neo-access-credentials
+    neo-controller
+    neo-device-manager
+    neo-eth-discovery
+    neo-ib
+    neo-ip-discovery
+    neo-monitor
+    neo-performance
+    neo-provisioning
+    neo-solution
+    neo-virtualization
+  ).each do |s|
+    it do
+      expect(chef_run).to enable_service(s)
+    end
+    it do
+      expect(chef_run).to start_service(s)
+    end
+  end
+
+  it do
+    expect(chef_run).to create_apache_app('fauxhai.local')
+      .with(
+        directory: '/opt/neo/controller/docs',
+        directive_http: [
+          'RewriteCond %{HTTPS} !=on',
+          'RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]'
+        ],
+        ssl_enable: true,
+        cert_chain: '/etc/pki/tls/certs/wildcard-bundle.crt',
+        cert_file: '/etc/pki/tls/certs/wildcard.pem',
+        cert_key: '/etc/pki/tls/private/wildcard.key',
+        include_config: true,
+        include_name: 'neo'
+      )
+  end
+end

--- a/templates/default/neo.conf.erb
+++ b/templates/default/neo.conf.erb
@@ -1,0 +1,30 @@
+ProxyRequests Off
+ProxyPreserveHost On
+RewriteEngine On
+
+<Proxy *>
+    Order deny,allow
+    Allow from all
+</Proxy>
+
+<Location />
+
+    ProxyPass http://127.0.0.1:5000
+    ProxyPassReverse http://127.0.0.1:5000
+
+    RequestHeader add X-Script-Name "/"
+    RequestHeader add X-Scheme 'http'
+    RequestHeader set X-Scheme 'https' env=HTTPS
+</Location>
+
+Redirect 307 /ufmvpi /
+
+<Directory "/opt/neo/controller/docs">
+    AllowOverride None
+    Options FollowSymLinks
+</Directory>
+
+<Location /neo-docs>
+</Location>
+
+alias "/neo-docs" "/opt/neo/controller/docs"

--- a/test/integration/mellanox_neo/serverspec/mellanox_neo_spec.rb
+++ b/test/integration/mellanox_neo/serverspec/mellanox_neo_spec.rb
@@ -1,0 +1,68 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe file('/etc/httpd/conf.d/neo.conf') do
+  it { should exist }
+end
+
+%w(
+  neo-controller
+  neo-provider-ac
+  neo-provider-common
+  neo-provider-discovery
+  neo-provider-dm
+  neo-provider-ethdisc
+  neo-provider-ib
+  neo-provider-monitor
+  neo-provider-performance
+  neo-provider-provisioning
+  neo-provider-solution
+  neo-provider-virtualization
+).each do |p|
+  describe package(p) do
+    it { should be_installed }
+  end
+end
+
+%w(
+  neo-access-credentials
+  neo-controller
+  neo-device-manager
+  neo-eth-discovery
+  neo-ib
+  neo-ip-discovery
+  neo-monitor
+  neo-performance
+  neo-provisioning
+  neo-solution
+  neo-virtualization
+).each do |s|
+  describe service(s) do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end
+
+%w(80 443).each do |p|
+  describe port(p) do
+    it { should be_listening }
+  end
+end
+
+curl_cmd = 'curl -v -H "Host: neo.osuosl.org" -k -o /dev/null -s'
+
+describe command("#{curl_cmd} http://127.0.0.1/ 2>&1") do
+  its(:stdout) { should match(%r{^< Location: https://neo.osuosl.org/}) }
+  its(:stdout) { should match(%r{^< HTTP/1.1 302 Found}) }
+end
+
+describe command("#{curl_cmd} https://127.0.0.1/ 2>&1") do
+  its(:stdout) { should match(%r{^< Location: https://neo.osuosl.org/neo/}) }
+  its(:stdout) { should match(%r{^< HTTP/1.1 302 Found}) }
+end
+
+describe command("#{curl_cmd} https://127.0.0.1/neo/ 2>&1") do
+  its(:stdout) { should match(%r{^< Location: https://neo.osuosl.org/neo/login\?next=%2Fneo%2F}) }
+  its(:stdout) { should match(/^< Set-Cookie: session=/) }
+end

--- a/test/smoke/default/mellanox_neo.rb
+++ b/test/smoke/default/mellanox_neo.rb
@@ -1,0 +1,6 @@
+# # encoding: utf-8
+
+# Inspec test for recipe osl-openstack::mellanox_neo
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at http://inspec.io/docs/reference/resources/


### PR DESCRIPTION
This basically converts what the installation script does into a chef managed
recipe. This is needed to integrate the OpenPOWER cluster with the Mellanox switch and will be run on its own VM eventually.

[1] https://community.mellanox.com/docs/DOC-2348

TODO:
- [x] Create systemd unit files for all services