### PR TITLE
Add lock for yum-epel

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -22,5 +22,6 @@ depends 'memcached', '= 3.0.0'
 depends 'user'
 depends 'yum', '= 3.5.4'
 depends 'yum-centos', '= 0.4.11'
+depends 'yum-epel', '= 0.6.5'
 
 supports         'centos', '~> 7.0'


### PR DESCRIPTION
This ensures that we use the correct version of the yum cookbook as well. When
0.6.6 is pulled in this breaks berks so we need to lock 0.6.5 for now.