### PR TITLE
writeback as default cache mode

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,6 +48,7 @@ node.default['openstack']['compute']['conf'].tap do |conf|
   conf['DEFAULT']['instance_usage_audit_period'] = 'hour'
   conf['DEFAULT']['notify_on_state_change'] = 'vm_and_task_state'
   conf['DEFAULT']['disk_allocation_ratio'] = 1.5
+  conf['libvirt']['disk_cachemodes'] = 'file=writeback,block=writeback'
 end
 node.default['openstack']['network'].tap do |conf|
   conf['conf']['DEFAULT']['service_plugins'] =

--- a/spec/compute_controller_spec.rb
+++ b/spec/compute_controller_spec.rb
@@ -78,6 +78,16 @@ nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver$/,
     end
 
     [
+      /^virt_type = kvm$/,
+      /^disk_cachemodes = file=writeback,block=writeback$/
+    ].each do |line|
+      it do
+        expect(chef_run).to render_config_file(file.name)
+          .with_section_content('libvirt', line)
+      end
+    end
+
+    [
       /^service_metadata_proxy = true$/,
       %r{^url = http://10.0.0.10:9696$},
       %r{^auth_url = https://10.0.0.10:5000/v2.0$}

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -70,6 +70,7 @@ Host *
         EOL
       )
   end
+
   %w(ppc64 ppc64le).each do |a|
     context "setting arch to #{a}" do
       cached(:chef_run) { runner.converge(described_recipe) }


### PR DESCRIPTION
**cache** parameter for qemu-kvm to be set to `writeback` by default.
    
**Related Discussions:**

* Trello card: https://trello.com/c/ZXx1mX4s
* Support ticket by Gentoo guys: https://support.osuosl.org/Ticket/Display.html?id=29271

**How this affects our instances:**

Any instance currently running will continue to have `cache = none`
Any instance hard-rebooted will change to having `cache = writeback`
Any instance newly created with also have this new setting.

This setting makes our preference to performance over integrity in the sense that if there is a ~~data~~ power loss, the cache will be lost. 

Setting this attribute here will affect ALL our openstack hypervisors - x86(?), x86_64 and ppc64le