### PR TITLE
Fixes the issue with volume not being attachable at all.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,7 +48,7 @@ node.default['openstack']['compute']['conf'].tap do |conf|
   conf['DEFAULT']['instance_usage_audit_period'] = 'hour'
   conf['DEFAULT']['notify_on_state_change'] = 'vm_and_task_state'
   conf['DEFAULT']['disk_allocation_ratio'] = 1.5
-  conf['libvirt']['disk_cachemodes'] = 'file=writeback,block=writeback'
+  conf['libvirt']['disk_cachemodes'] = 'file=writeback,block=none'
 end
 node.default['openstack']['network'].tap do |conf|
   conf['conf']['DEFAULT']['service_plugins'] =

--- a/spec/compute_controller_spec.rb
+++ b/spec/compute_controller_spec.rb
@@ -79,7 +79,7 @@ nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver$/,
 
     [
       /^virt_type = kvm$/,
-      /^disk_cachemodes = file=writeback,block=writeback$/
+      /^disk_cachemodes = file=writeback,block=none$/
     ].each do |line|
       it do
         expect(chef_run).to render_config_file(file.name)


### PR DESCRIPTION
Basically #75 introduced a bug -- volumes we provide using LVM backend could not be attached at all to any instance.

The `writeback` mode on block devices is unsupported 

Basically, it resulted in the error 
```
libvirtError: unsupported configuration: native I/O needs either no disk cache or directsync cache mode, QEMU will fallback to aio=threads
```

This PR fixes that issue and at the same time, continues to ensure that we get the write performance we originally desired with #75.

This PR does *NOT* fix the issue with the volumes being *unmountable* on some instances which we are still working on.