### PR TITLE
Use controller.example.com for all endpoints and port binding in test-kitchen

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,7 +11,14 @@ provisioner:
       database_suffix: x86
       databag_prefix: x86
       endpoint_hostname: controller.example.com
+      db_hostname: controller.example.com
+      bind_service: 127.0.0.1
+      vxlan_interface:
+        controller:
+          default: lo
       nova_public_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYOuLkP1F/Sm/dCJAA7kme+ObO4J8x2HrZU40W8QqW4yFqRPKnW5HYLeUpRzIFzWen/LIn6R6lxTfSAnnD8qEEuKbFjH5WRqJYCJeAyaTBTRyU1FHlcTR/EQ/HVZ38TQwCztZgboFb5zmWqYc3/BYBHGA6XeYN5jRcHvZbyaGL+YA1/KPIjpbQfqIPXdHfodoSNX4qQQccYBq2c/rq3Puh7Q9oVph6a2lq0wWsqYyq0vTGHPKFYShVpwDl2Z3c8eB3P7yFRzOR2VNuezJlOgoHz6D/mBObLj1n+yi07bcGbpwAH/rLEyiy4gVdru2qQAcbDL9Yibk96lovim/IH4dV nova-migration
+    openstack_test:
+      gluster_host: controller.example.com
     openstack:
       secret:
         key_path: "/tmp/kitchen/encrypted_data_bag_secret"
@@ -25,7 +32,7 @@ provisioner:
     yum:
       epel:
         baseurl: http://epel.osuosl.org/7/$basearch
-        enable: true
+        enabled: true
         gpgkey: http://epel.osuosl.org/RPM-GPG-KEY-EPEL-7
     scl:
       packages:
@@ -146,11 +153,10 @@ suites:
       - recipe[openstack_test::gluster]
       - recipe[osl-openstack::controller]
       - recipe[osl-openstack::compute]
-      - recipe[osl-openstack::cinder]
+      - recipe[osl-openstack::block_storage]
       - recipe[openstack-integration-test::setup]
     attributes:
       osl-openstack:
-        endpoint_hostname: localhost
         cinder:
           iscsi_role: openstack_base
           iscsi_ips:

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -69,7 +69,7 @@ node.default['openstack']['network_dhcp']['conf'].tap do |conf|
   conf['DEFAULT']['dhcp_lease_duration'] = 120
 end
 node.default['openstack']['network_metadata']['conf'].tap do |conf|
-  conf['DEFAULT']['nova_metadata_ip'] = node['ipaddress']
+  conf['DEFAULT']['nova_metadata_ip'] = node['osl-openstack']['bind_service']
 end
 node.override['openstack']['network']['plugins']['ml2']['conf'].tap do |conf|
   conf['ml2']['type_drivers'] = 'flat,vlan,vxlan'

--- a/test/cookbooks/openstack_test/attributes/gluster.rb
+++ b/test/cookbooks/openstack_test/attributes/gluster.rb
@@ -1,0 +1,1 @@
+default['openstack_test']['gluster_host'] = node['ipaddress']

--- a/test/cookbooks/openstack_test/recipes/cacert.rb
+++ b/test/cookbooks/openstack_test/recipes/cacert.rb
@@ -1,5 +1,9 @@
 include_recipe 'certificate::wildcard'
 
+package 'ca-certificates' do
+  action :upgrade
+end
+
 execute 'copy self-signed ca-cert' do
   command <<-EOF
     cat /etc/pki/tls/certs/wildcard-bundle.crt >> \

--- a/test/cookbooks/openstack_test/recipes/gluster.rb
+++ b/test/cookbooks/openstack_test/recipes/gluster.rb
@@ -11,12 +11,10 @@ directory '/data/openstack-glance' do
 end
 execute 'create gluster glance volume' do
   command <<-EOH
-    gluster volume create openstack-glance \
-      #{node['ipaddress']}:/data/openstack-glance force
+    gluster volume create openstack-glance #{node['openstack_test']['gluster_host']}:/data/openstack-glance force
     gluster volume start openstack-glance
   EOH
   not_if 'gluster volume status openstack-glance'
 end
 
-node.default['osl-openstack']['image']['glance_vol'] =
-  "#{node['ipaddress']}:/openstack-glance"
+node.default['osl-openstack']['image']['glance_vol'] = "#{node['openstack_test']['gluster_host']}:/openstack-glance"

--- a/test/cookbooks/openstack_test/recipes/hosts.rb
+++ b/test/cookbooks/openstack_test/recipes/hosts.rb
@@ -1,3 +1,4 @@
-hostsfile_entry node['ipaddress'] do
+hostsfile_entry node['osl-openstack']['bind_service'] do
   hostname 'controller.example.com'
+  action :append
 end

--- a/test/integration/compute_controller/serverspec/compute_controller_spec.rb
+++ b/test/integration/compute_controller/serverspec/compute_controller_spec.rb
@@ -80,11 +80,7 @@ describe command('source /root/openrc && openstack compute service list') do
   end
 end
 
-# Get the primary IP address since we bind specifically to it.
-require 'socket'
-machine_ip = Socket.ip_address_list[1].ip_address
-
-describe command("curl -k -v https://#{machine_ip}:6080 2>&1") do
+describe command('curl -k -v https://controller.example.com:6080 2>&1') do
   its(:stdout) { should contain(/SSL connection/) }
   its(:stdout) { should contain(/HTTP.*200 OK/) }
 end


### PR DESCRIPTION
This shifts things over to make testing this environment easier and not use VM
specific IP addresses. These changes are needed to properly test upgrades
between Mitaka and Newton.

- Use same endpoint/binding settings globally in test-kitchen
- Set db_hostname to controller.example.com
- Set bind_service to 127.0.0.1
- Set default vxlan interface to lo
- Set gluster_host to controller.example.com
- Fix yum epel attribute name
- Use node['osl-openstack']['bind_service'] instead of node['ipaddress'] in
  various places so we can change this globally if we need to
- Upgrade ca-certificates package before appending our CA to it to prevent
  further issues when running yum upgrade
- Append /etc/hosts entry for controller.example.com so we don't overwrite
  localhost entries
- Update reference to block_storage recipe in allinone suite