### PR TITLE
Updating Berksfile as the OpenStack Chef upstream has tagged Mitaka as EOL

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -39,7 +39,7 @@ cookbook 'ibm-power', git: 'git@github.com:osuosl-cookbooks/ibm-power.git'
 ).each do |cb|
   cookbook "openstack-#{cb}",
            github: "openstack/cookbook-openstack-#{cb}",
-           branch: 'stable/mitaka'
+           tag: 'mitaka-eol'
 end
 
 cookbook 'openstack_test', path: 'test/cookbooks/openstack_test'


### PR DESCRIPTION
They will be removing the stable/mitaka branch soon likely so this is to prepare
for that to happen and reduce any development problems.