### PR TITLE
Add iptable rules to block external DNS traffic on public provider networks

### DIFF
--- a/recipes/network.rb
+++ b/recipes/network.rb
@@ -27,3 +27,17 @@ include_recipe 'openstack-network::server'
 include_recipe 'openstack-network::l3_agent'
 include_recipe 'openstack-network::dhcp_agent'
 include_recipe 'openstack-network::metadata_agent'
+
+# Block external DNS requests to networks we have selected. This is to prevent them to be seen as open resolvers and
+# used in amplification attacks.
+node['osl-openstack']['physical_interface_mappings'].each do |network|
+  next if network['subnet'].nil? || network['uuid'].nil?
+  ip_cmd = "ip netns exec qdhcp-#{network['uuid']}"
+  bash "block external dns on #{network['name']}" do
+    code <<-EOL
+#{ip_cmd} iptables -A INPUT -p tcp --dport 53 ! -s #{network['subnet']} -j DROP
+#{ip_cmd} iptables -A INPUT -p udp --dport 53 ! -s #{network['subnet']} -j DROP
+    EOL
+    not_if "#{ip_cmd} iptables -S | egrep \"#{network['subnet']}.*port 53.*DROP\""
+  end
+end


### PR DESCRIPTION
This will resolve #40 provided we add the attributes for each network we want
this enabled on in their role. Later we can figure out how to automatically pull
the UUID but for now this will do.