### PR TITLE
Properly fix situations where the initial run has interfaces not setup

### DIFF
--- a/recipes/linuxbridge.rb
+++ b/recipes/linuxbridge.rb
@@ -38,13 +38,18 @@ vxlan_interface = if vxlan[node_type][node['fqdn']]
                     vxlan[node_type]['default']
                   end
 vxlan_addrs = node['network']['interfaces'][vxlan_interface]
-vxlan_ip = if vxlan_addrs.nil?
+vxlan_ip = if vxlan_addrs.nil? || vxlan_addrs['addresses'].empty?
              # Fall back to localhost if the interface has no IP
              '127.0.0.1'
            else
-             vxlan_addrs['addresses'].find do |_, attrs|
+             address = vxlan_addrs['addresses'].find do |_, attrs|
                attrs['family'] == 'inet'
-             end[0]
+             end
+             if address.nil?
+               '127.0.0.1'
+             else
+               address[0]
+             end
            end
 
 node.default['openstack']['network']['plugins']['linuxbridge']['conf']

--- a/spec/linuxbridge_spec.rb
+++ b/spec/linuxbridge_spec.rb
@@ -79,9 +79,11 @@ neutron.agent.linux.iptables_firewall.IptablesFirewallDriver$/
       cached(:chef_run) { runner.converge(described_recipe) }
       before do
         node.set['osl-openstack']['node_type'] = 'controller'
-        node.set['osl-openstack']['vxlan_interface']['controller'] \
-          ['default'] = 'eth2'
-        node.automatic['network']['interfaces']['eth1']['addresses'] = {}
+        node.set['osl-openstack']['vxlan_interface']['controller']['default'] = 'eth2'
+        node.automatic['network']['interfaces']['eth2']['addresses'] = {
+          'AA:00:00:4A:A6:6E' => { 'family' => 'lladdr' },
+          'fe80::a800:ff:fe4a:a66e' => { 'family' => 'inet6', 'prefixlen' => '64', 'scope' => 'Link', 'tags' => [] }
+        }
       end
       it do
         expect(chef_run).to render_config_file(file.name)


### PR DESCRIPTION
I thought I had this fixed before but apparently not. It seems the original test
wasn't updated properly. I verified this should fix the problem I'm currently
running into in our test environment.