### PR TITLE
Update RDO baseurl for Mitaka release

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,9 +28,8 @@ node.default['openstack']['secret']['key_path'] =
 node.default['openstack']['misc_openrc'] = [
   'export OS_CACERT=""'
 ]
-node.default['openstack']['yum']['uri'] = \
-  'http://centos.osuosl.org/$releasever/cloud/x86_64/openstack-' +
-  node['openstack']['release']
+node.default['openstack']['yum']['uri'] =
+  'http://centos.osuosl.org/7.3.1611/cloud/x86_64/openstack-' + node['openstack']['release']
 node.default['openstack']['yum']['repo-key'] = 'https://github.com/' \
  "rdo-infra/rdo-release/raw/#{node['openstack']['release']}-rdo/" \
  'RPM-GPG-KEY-CentOS-SIG-Cloud'


### PR DESCRIPTION
Upstream has removed Mitaka from the 7.4 release tree but it remains in the 7.3
tree. So this updates the pointer to use that location instead for Mitaka
releases.