### PR TITLE
Exclude python2-uritemplate python2-google-api-client from epel repo

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -307,6 +307,19 @@ yum_repository 'OSL-openpower-openstack' do
   action :add
 end
 
+include_recipe 'yum-epel'
+
+node['yum-epel']['repositories'].each do |repo|
+  next unless node['yum'][repo]['managed']
+  r = resources(yum_repository: repo)
+  # If we already have excludes, include them and append these packages which are causing dependency issues.
+  r.exclude = [
+    r.exclude,
+    'python2-uritemplate',
+    'python2-google-api-client'
+  ].reject(&:nil?).join(' ')
+end
+
 include_recipe 'base::ifconfig'
 include_recipe 'firewall'
 include_recipe 'selinux::permissive'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -40,6 +40,9 @@ describe 'osl-openstack::default' do
     end
   end
   it do
+    expect(chef_run).to create_yum_repository('epel').with(exclude: 'python2-uritemplate python2-google-api-client')
+  end
+  it do
     expect(chef_run).to install_package('python-memcached')
   end
   it do

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -7,6 +7,10 @@ describe yumrepo('RDO-mitaka') do
   it { should be_enabled }
 end
 
+describe file('/etc/yum.repos.d/epel.repo') do
+  its(:content) { should match(/^exclude=python2-uritemplate python2-google-api-client$/) }
+end
+
 describe file('/root/openrc') do
   its(:content) do
     should match(%r{


### PR DESCRIPTION
These two packages conflict with packages included in the RDO-mitaka repo so
let's exclude them.