### PR TITLE
Arcfour cipher has been completely removed

### DIFF
--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -86,7 +86,6 @@ file '/var/lib/nova/.ssh/config' do
   content <<-EOL
 Host *
   StrictHostKeyChecking no
-  Ciphers arcfour
   UserKnownHostsFile /dev/null
   EOL
   user 'nova'

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -61,7 +61,6 @@ describe 'osl-openstack::compute' do
         content: <<-EOL
 Host *
   StrictHostKeyChecking no
-  Ciphers arcfour
   UserKnownHostsFile /dev/null
         EOL
       )

--- a/test/integration/compute/serverspec/compute_spec.rb
+++ b/test/integration/compute/serverspec/compute_spec.rb
@@ -69,7 +69,6 @@ describe file('/var/lib/nova/.ssh/config') do
   its(:content) do
     should match(%r{^Host \*
   StrictHostKeyChecking no
-  Ciphers arcfour
   UserKnownHostsFile /dev/null$})
   end
   it { should be_mode 600 }


### PR DESCRIPTION
I tried running a migrate the other day and ran into this issue. This should
resolve the issue.