### PR TITLE
Add AggregateInstanceExtraSpecsFilter to Nova Scheduler

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,8 +46,14 @@ node.default['openstack']['identity']['ssl'].tap do |conf|
   conf['chainfile'] = '/etc/pki/tls/certs/wildcard-bundle.crt'
 end
 node.default['openstack']['compute']['conf'].tap do |conf|
-  conf['DEFAULT']['linuxnet_interface_driver'] = \
-    'nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver'
+  conf['DEFAULT']['scheduler_default_filters'] =
+    %w(
+      AggregateInstanceExtraSpecsFilter
+      AvailabilityZoneFilter
+      RamFilter
+      ComputeFilter
+    ).join(',')
+  conf['DEFAULT']['linuxnet_interface_driver'] = 'nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver'
   conf['DEFAULT']['dns_server'] = '140.211.166.130 140.211.166.131'
   conf['DEFAULT']['instance_usage_audit'] = 'True'
   conf['DEFAULT']['instance_usage_audit_period'] = 'hour'

--- a/spec/compute_controller_spec.rb
+++ b/spec/compute_controller_spec.rb
@@ -29,8 +29,9 @@ describe 'osl-openstack::compute_controller' do
     let(:file) { chef_run.template('/etc/nova/nova.conf') }
 
     [
-      /^linuxnet_interface_driver = \
-nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver$/,
+      /^scheduler_default_filters = \
+AggregateInstanceExtraSpecsFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter$/,
+      /^linuxnet_interface_driver = nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver$/,
       /^dns_server = 140.211.166.130 140.211.166.131$/,
       /^disk_allocation_ratio = 1.5$/,
       /^instance_usage_audit = True$/,

--- a/test/integration/compute_controller/serverspec/compute_controller_spec.rb
+++ b/test/integration/compute_controller/serverspec/compute_controller_spec.rb
@@ -24,8 +24,9 @@ end
 end
 
 [
-  'linuxnet_interface_driver = ' \
-  'nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver',
+  'scheduler_default_filters = ' \
+  'AggregateInstanceExtraSpecsFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter',
+  'linuxnet_interface_driver = nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver',
   'dns_server = 140.211.166.130 140.211.166.131',
   'disk_allocation_ratio = 1.5',
   'instance_usage_audit = True',


### PR DESCRIPTION
This allows us to schedule VM placement based on host aggregates.