### PR TITLE
Switch to using our fork of osops-tools-monitoring

### DIFF
--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -66,8 +66,8 @@ if node['osl-openstack']['node_type'] == 'controller'
   end
 
   git tools_dir do
-    revision '62160d10683023c8c9d96f616223d8def88b870d'
-    repository 'https://git.openstack.org/openstack/osops-tools-monitoring'
+    revision 'osuosl'
+    repository 'https://github.com/osuosl/osops-tools-monitoring.git'
     notifies :run, 'python_execute[monitoring-for-openstack deps]', :immediately
     notifies :run, 'python_execute[monitoring-for-openstack install]', :immediately
   end

--- a/spec/mon_spec.rb
+++ b/spec/mon_spec.rb
@@ -51,8 +51,8 @@ describe 'osl-openstack::mon' do
     it do
       expect(chef_run).to sync_git('/var/chef/cache/osops-tools-monitoring')
         .with(
-          revision: '62160d10683023c8c9d96f616223d8def88b870d',
-          repository: 'https://git.openstack.org/openstack/osops-tools-monitoring'
+          revision: 'osuosl',
+          repository: 'https://github.com/osuosl/osops-tools-monitoring.git'
         )
     end
     it do


### PR DESCRIPTION
This includes some local fixes for the nova-api checks that need to be fixed
upstream. This also gives us more control over what we use in production.