### PR TITLE
Disable volumes from instance launch window in Horizon

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -108,6 +108,13 @@ node.default['openstack']['dashboard'].tap do |conf|
   conf['ssl']['key'] = 'wildcard.key'
   conf['ssl']['cert'] = 'wildcard.pem'
   conf['ssl']['chain'] = 'wildcard-bundle.crt'
+  conf['misc_local_settings'] = {
+    'LAUNCH_INSTANCE_DEFAULTS' => {
+      create_volume: false, # Not available until Pike
+      disable_volume: true,
+      disable_volume_snapshot: true
+    }
+  }
 end
 
 node.default['openstack']['telemetry']['conf'].tap do |conf|

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -42,6 +42,15 @@ describe 'osl-openstack::dashboard', dashboard: true do
     expect(chef_run.node['openstack']['dashboard']['ssl'] \
       ['chain']).to eq('wildcard-bundle.crt')
   end
+  it do
+    expect(chef_run).to render_file('/etc/openstack-dashboard/local_settings')
+      .with_content(/
+LAUNCH_INSTANCE_DEFAULTS = {
+  'create_volume': 'false',
+  'disable_volume': 'true',
+  'disable_volume_snapshot': 'true',
+}/)
+  end
   context 'Secret files already exist' do
     let(:chef_run) { runner.converge(described_recipe) }
     it 'Set secret key lock file permissions' do

--- a/test/integration/dashboard/serverspec/dashboard_spec.rb
+++ b/test/integration/dashboard/serverspec/dashboard_spec.rb
@@ -16,6 +16,14 @@ MemcachedCache',/)
   its(:content) do
     should contain(/'LOCATION': \[\n\s*'.*:11211',/)
   end
+  its(:content) do
+    should match(/
+LAUNCH_INSTANCE_DEFAULTS = {
+  'create_volume': 'false',
+  'disable_volume': 'true',
+  'disable_volume_snapshot': 'true',
+}/)
+  end
 end
 
 # Simulate logging into horizon with curl and test the output to ensure the


### PR DESCRIPTION
This disables the new default setting which displays using volumes for instances
in Newton using settings found here[1]. We don't have support for this working
in our current cluster so this disables it. Unfortunately, one of the settings
(create_volume) isn't available until Pike but I'm including it in here anyway
once we get there. Uses will still need to select "No" to create volume in the
UI.

[1] https://docs.openstack.org/horizon/latest/configuration/settings.html#launch-instance-defaults