### PR TITLE
Enable OpenStack Orchestration service (heat)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -129,6 +129,11 @@ suites:
       - role[openstack_tk]
       - role[openstack_ops_identity]
       - recipe[osl-openstack::telemetry]
+  - name: orchestration
+    run_list:
+      - role[openstack_tk]
+      - role[openstack_ops_identity]
+      - recipe[osl-openstack::orchestration]
   - name: mellanox_neo
     attributes:
       osl-openstack:
@@ -153,6 +158,7 @@ suites:
       - recipe[osl-openstack::compute]
       - recipe[osl-openstack::block_storage]
       - recipe[openstack-integration-test::setup]
+      - recipe[openstack_test::orchestration]
     attributes:
       osl-openstack:
         cinder:

--- a/recipes/controller.rb
+++ b/recipes/controller.rb
@@ -29,6 +29,7 @@ include_recipe 'osl-openstack::image'
 include_recipe 'osl-openstack::network' unless node['osl-openstack']['separate_network_node']
 include_recipe 'osl-openstack::compute_controller'
 include_recipe 'osl-openstack::block_storage_controller'
+include_recipe 'osl-openstack::orchestration'
 include_recipe 'osl-openstack::telemetry'
 include_recipe 'osl-openstack::dashboard'
 include_recipe 'osl-openstack::mon'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -233,6 +233,7 @@ end
   network_l3
   network_metadata
   network_metering
+  orchestration
   telemetry
 ).each do |i|
   rabbit_user = node['openstack']['mq']['network']['rabbit']['userid']
@@ -283,6 +284,9 @@ end
   compute-vnc-proxy
   compute-api
   compute-serial-proxy
+  orchestration-api
+  orchestration-api-cfn
+  orchestration-api-cloudwatch
   telemetry
   telemetry-metric
 ).each do |service|

--- a/recipes/orchestration.rb
+++ b/recipes/orchestration.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook:: osl-openstack
+# Recipe:: orchestration
+#
+# Copyright:: 2017, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_recipe 'osl-openstack'
+include_recipe 'openstack-orchestration::engine'
+include_recipe 'openstack-orchestration::api'
+include_recipe 'openstack-orchestration::api-cfn'
+include_recipe 'openstack-orchestration::api-cloudwatch'
+include_recipe 'openstack-orchestration::identity_registration'

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -14,6 +14,7 @@ describe 'osl-openstack::controller' do
     block_storage_stubs
     dashboard_stubs
     telemetry_stubs
+    orchestration_stubs
   ).each do |s|
     include_context s
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,9 @@ shared_context 'identity_stubs' do
     allow_any_instance_of(Chef::Recipe).to receive(:get_password)
       .with('user', 'admin')
       .and_return('admin')
+    allow_any_instance_of(Chef::Recipe).to receive(:rabbit_transport_url)
+      .with('identity')
+      .and_return('rabbit://openstack:openstack@controller.example.org:5672')
   end
 end
 
@@ -106,6 +109,9 @@ shared_context 'image_stubs' do
     allow_any_instance_of(Chef::Recipe).to receive(:get_password)
       .with('user', 'admin')
       .and_return('admin-pass')
+    allow_any_instance_of(Chef::Recipe).to receive(:rabbit_transport_url)
+      .with('image')
+      .and_return('rabbit://openstack:openstack@controller.example.org:5672')
   end
 end
 
@@ -130,6 +136,9 @@ shared_context 'network_stubs' do
     allow_any_instance_of(Chef::Recipe).to receive(:get_password)
       .with('service', 'openstack-compute')
       .and_return('nova-pass')
+    allow_any_instance_of(Chef::Recipe).to receive(:rabbit_transport_url)
+      .with('network')
+      .and_return('rabbit://openstack:openstack@controller.example.org:5672')
   end
   shared_examples 'custom template banner displayer' do
     it 'shows the custom banner' do
@@ -222,6 +231,9 @@ shared_context 'compute_stubs' do
     stub_command('virsh net-list | grep -q default').and_return(true)
     stub_command("/sbin/ppc64_cpu --smt 2>&1 | grep -E 'SMT is off|Machine is" \
       " not SMT capable'").and_return(false)
+    allow_any_instance_of(Chef::Recipe).to receive(:rabbit_transport_url)
+      .with('compute')
+      .and_return('rabbit://openstack:openstack@controller.example.org:5672')
   end
 end
 
@@ -263,6 +275,9 @@ shared_context 'block_storage_stubs' do
       .with('user', 'ibmnas_admin')
       .and_return('test_pass')
     allow(Chef::Application).to receive(:fatal!)
+    allow_any_instance_of(Chef::Recipe).to receive(:rabbit_transport_url)
+      .with('block-storage')
+      .and_return('rabbit://openstack:openstack@controller.example.org:5672')
   end
 end
 
@@ -314,6 +329,45 @@ shared_context 'telemetry_stubs' do
     allow_any_instance_of(Chef::Recipe).to receive(:get_password)
       .with('token', 'openstack_identity_bootstrap_token')
       .and_return('bootstrap-token')
+    allow(Chef::Application).to receive(:fatal!)
+    allow_any_instance_of(Chef::Recipe).to receive(:rabbit_transport_url)
+      .with('telemetry')
+      .and_return('rabbit://openstack:openstack@controller.example.org:5672')
+  end
+end
+
+shared_context 'orchestration_stubs' do
+  before do
+    allow_any_instance_of(Chef::Recipe).to receive(:rabbit_servers)
+      .and_return '1.1.1.1:5672,2.2.2.2:5672'
+    allow_any_instance_of(Chef::Recipe).to receive(:address_for)
+      .with('lo')
+      .and_return '127.0.1.1'
+    allow_any_instance_of(Chef::Recipe).to receive(:get_password)
+      .with('token', 'openstack_identity_bootstrap_token')
+      .and_return 'bootstrap-token'
+
+    allow_any_instance_of(Chef::Recipe).to receive(:get_password)
+      .with('db', 'heat')
+      .and_return 'heat'
+    allow_any_instance_of(Chef::Recipe).to receive(:get_password)
+      .with('user', 'guest')
+      .and_return 'mq-pass'
+    allow_any_instance_of(Chef::Recipe).to receive(:get_password)
+      .with('user', 'admin-user')
+      .and_return 'admin-pass'
+    allow_any_instance_of(Chef::Recipe).to receive(:get_password)
+      .with('service', 'openstack-orchestration')
+      .and_return 'heat-pass'
+    allow_any_instance_of(Chef::Recipe).to receive(:get_password)
+      .with('user', 'admin')
+      .and_return 'admin-pass'
+    allow_any_instance_of(Chef::Recipe).to receive(:get_password)
+      .with('token', 'orchestration_auth_encryption_key')
+      .and_return 'auth_encryption_key_secret'
+    allow_any_instance_of(Chef::Recipe).to receive(:rabbit_transport_url)
+      .with('orchestration')
+      .and_return('rabbit://openstack:openstack@controller.example.org:5672')
     allow(Chef::Application).to receive(:fatal!)
   end
 end

--- a/spec/unit/recipes/orchestration_spec.rb
+++ b/spec/unit/recipes/orchestration_spec.rb
@@ -1,0 +1,105 @@
+require_relative '../../spec_helper'
+
+describe 'osl-openstack::orchestration' do
+  let(:runner) do
+    ChefSpec::SoloRunner.new(REDHAT_OPTS)
+  end
+  let(:node) { runner.node }
+  cached(:chef_run) { runner.converge(described_recipe) }
+  include_context 'common_stubs'
+  include_context 'identity_stubs'
+  include_context 'orchestration_stubs'
+  it 'converges successfully' do
+    expect { chef_run }.to_not raise_error
+  end
+  describe '/etc/heat/heat.conf' do
+    let(:file) { chef_run.template('/etc/heat/heat.conf') }
+
+    [
+      %r{^heat_metadata_server_url = http://10.0.0.10:8000$},
+      %r{^heat_waitcondition_server_url = http://10.0.0.10:8000/v1/waitcondition$},
+      %r{^heat_watch_server_url = http://10.0.0.10:8003$},
+      %r{^transport_url = rabbit://guest:mq-pass@10.0.0.10:5672$}
+    ].each do |line|
+      it do
+        expect(chef_run).to render_config_file(file.name).with_section_content('DEFAULT', line)
+      end
+    end
+    %w(heat_api heat_api_cfn heat_api_cloudwatch).each do |service|
+      it do
+        expect(chef_run).to render_config_file(file.name)
+          .with_section_content(
+            service,
+            /^bind_host = 10.0.0.2$/
+          )
+      end
+    end
+
+    context 'Set bind_service' do
+      let(:runner) do
+        ChefSpec::SoloRunner.new(REDHAT_OPTS)
+      end
+      let(:node) { runner.node }
+      cached(:chef_run) { runner.converge(described_recipe) }
+      include_context 'common_stubs'
+      %w(heat_api heat_api_cfn heat_api_cloudwatch).each do |service|
+        it do
+          node.set['osl-openstack']['bind_service'] = '192.168.1.1'
+          expect(chef_run).to render_config_file(file.name)
+            .with_section_content(
+              service,
+              /^bind_host = 192.168.1.1$/
+            )
+        end
+      end
+    end
+
+    it do
+      expect(chef_run).to render_config_file(file.name)
+        .with_section_content(
+          'oslo_messaging_notifications',
+          /^driver = messagingv2$/
+        )
+    end
+    [
+      /^backend = oslo_cache.memcache_pool$/,
+      /^enabled = true$/,
+      /^memcache_servers = 10.0.0.10:11211$/
+    ].each do |line|
+      it do
+        expect(chef_run).to render_config_file(file.name)
+          .with_section_content('cache', line)
+      end
+    end
+
+    [
+      /^memcached_servers = 10.0.0.10:11211$/,
+      %r{^auth_url = https://10.0.0.10:5000/v3$}
+    ].each do |line|
+      it do
+        expect(chef_run).to render_config_file(file.name)
+          .with_section_content('keystone_authtoken', line)
+      end
+    end
+
+    [
+      /^rabbit_host = 10.0.0.10$/,
+      /^rabbit_userid = guest$/,
+      /^rabbit_password = mq-pass$/
+    ].each do |line|
+      it do
+        expect(chef_run).to render_config_file(file.name)
+          .with_section_content('oslo_messaging_rabbit', line)
+      end
+    end
+
+    [
+      %r{^connection = mysql://heat_x86:heat@10.0.0.10:3306/heat_x86\?charset=utf8$}
+    ].each do |line|
+      it do
+        expect(chef_run).to render_config_file(file.name)
+          .with_section_content('database', line)
+      end
+    end
+  end
+end

--- a/test/cookbooks/openstack_test/files/default/heat.yml
+++ b/test/cookbooks/openstack_test/files/default/heat.yml
@@ -1,0 +1,11 @@
+heat_template_version: 2015-04-30
+
+description: Simple template to deploy a single compute instance
+
+resources:
+  my_instance:
+    type: OS::Nova::Server
+    properties:
+      key_name: heat_key
+      image: cirros
+      flavor: m1.small

--- a/test/cookbooks/openstack_test/recipes/orchestration.rb
+++ b/test/cookbooks/openstack_test/recipes/orchestration.rb
@@ -1,0 +1,9 @@
+execute 'source /root/openrc && openstack keypair create heat_key > /tmp/heat_key.priv' do
+  creates '/tmp/heat_key.priv'
+end
+
+execute 'source /root/openrc && openstack flavor create --ram 1024 --disk 15 --vcpus 1 m1.small' do
+  not_if 'source /root/openrc && openstack flavor show m1.small'
+end
+
+cookbook_file '/tmp/heat.yml'

--- a/test/integration/allinone/serverspec/allinone_spec.rb
+++ b/test/integration/allinone/serverspec/allinone_spec.rb
@@ -1,0 +1,12 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe command('source /root/openrc && openstack stack create -t /tmp/heat.yml stack') do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('source /root/openrc && openstack stack show stack -c stack_status -f value') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/^CREATE_IN_PROGRESS|CREATE_COMPLETE$/) }
+end

--- a/test/integration/default/data_bags/x86_secrets/orchestration_auth_encryption_key.json
+++ b/test/integration/default/data_bags/x86_secrets/orchestration_auth_encryption_key.json
@@ -1,0 +1,10 @@
+{
+  "id": "orchestration_auth_encryption_key",
+  "orchestration_auth_encryption_key": {
+    "encrypted_data": "cCyEp8EbQb61/VHdlT8fCh/1jfZjut1xx5Vd975U6jH9tbFndCiZe/M6Dztc\nX7KVYYph4fg42muZi3G9yHjB2Q==\n",
+    "hmac": "Lxd+nRyS/LsRFpWfZhpNJvIPSTLsqeFtZJ/na+39N3Q=\n",
+    "iv": "zMlaATlFHwW8kpNkJYKVKg==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  }
+}

--- a/test/integration/default/data_bags/x86_service_passwords/openstack-orchestration.json
+++ b/test/integration/default/data_bags/x86_service_passwords/openstack-orchestration.json
@@ -1,0 +1,10 @@
+{
+  "id": "openstack-orchestration",
+  "openstack-orchestration": {
+    "encrypted_data": "WLrdEYvl1Oj+vEhXu/BcTP2KkuI3I28Fu1i3zNwjlzld9rsajTB4WX9Xd/Xh\nzvkI\n",
+    "hmac": "GRMw/UWGn1rm5gIFMu5HEjLauQ0Wr4Zlezy2DAz4CNc=\n",
+    "iv": "GvU4RmsHJbjnEzrWFzMRow==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  }
+}

--- a/test/integration/orchestration/serverspec/orchestration_spec.rb
+++ b/test/integration/orchestration/serverspec/orchestration_spec.rb
@@ -1,0 +1,44 @@
+require 'serverspec'
+
+set :backend, :exec
+
+%w(
+  openstack-heat-api-cfn
+  openstack-heat-api-cloudwatch
+  openstack-heat-api
+  openstack-heat-engine
+).each do |s|
+  describe service(s) do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end
+
+%w(
+  8000
+  8003
+  8004
+).each do |p|
+  describe port(p) do
+    it { should be_listening.with('tcp') }
+  end
+end
+
+describe file('/etc/heat/heat.conf') do
+  its(:content) do
+    should contain(/memcached_servers = .*:11211/).from(/^\[keystone_authtoken\]$/).to(/^\[/)
+  end
+  its(:content) do
+    should contain(/memcache_servers = .*:11211/).from(/^\[cache\]$/).to(/^\[/)
+  end
+  its(:content) do
+    should contain(/driver = messagingv2/).from(/^\[oslo_messaging_notifications\]$/).to(/^\[/)
+  end
+end
+
+describe command(
+  'source /root/openrc && /usr/local/bin/openstack orchestration service list -c binary -c status -f value'
+) do
+  its(:stdout) { should match(/^heat-engine up$/) }
+  its(:stdout) { should_not match(/^heat-engine down$/) }
+end


### PR DESCRIPTION
This should resolve #61.

*NOTE: For whatever reason the ServerSpec test for enabling the openstack-heat-api-cfn service fails. However if you converge again and run verify it passes. I can't figure out why this is happening but it might be a Chef bug itself.*