### PR TITLE
Don't restart this service when the config file updates

### DIFF
--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -55,7 +55,6 @@ include_recipe 'openstack-telemetry::agent-compute'
 
 template '/etc/sysconfig/libvirt-guests' do
   variables(libvirt_guests: node['osl-openstack']['libvirt_guests'])
-  notifies :restart, 'service[libvirt-guests]'
 end
 
 service 'libvirt-guests' do

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -51,10 +51,6 @@ describe 'osl-openstack::compute' do
     end
   end
   it do
-    expect(chef_run.template('/etc/sysconfig/libvirt-guests')).to \
-      notify('service[libvirt-guests]')
-  end
-  it do
     expect(chef_run).to enable_service('libvirt-guests')
   end
   it do


### PR DESCRIPTION
If we do this and run stop, it will shutdown all the vms which is not what we
want!