### PR TITLE
Increase block_device_allocate_retries from 60 (default) to 120

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,6 +60,7 @@ node.default['openstack']['compute']['conf'].tap do |conf|
   conf['DEFAULT']['notify_on_state_change'] = 'vm_and_task_state'
   conf['DEFAULT']['disk_allocation_ratio'] = 1.5
   conf['DEFAULT']['resume_guests_state_on_host_boot'] = 'True'
+  conf['DEFAULT']['block_device_allocate_retries'] = 120
   conf['libvirt']['disk_cachemodes'] = 'file=writeback,block=none'
 end
 node.default['openstack']['network'].tap do |conf|

--- a/spec/compute_controller_spec.rb
+++ b/spec/compute_controller_spec.rb
@@ -40,6 +40,7 @@ AggregateInstanceExtraSpecsFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter
       /^osapi_compute_listen = 10.0.0.2$/,
       /^metadata_listen = 10.0.0.2$/,
       /^resume_guests_state_on_host_boot = True$/,
+      /^block_device_allocate_retries = 120$/,
       %r{^transport_url = rabbit://guest:mq-pass@10.0.0.10:5672$}
     ].each do |line|
       it do

--- a/test/integration/compute_controller/serverspec/compute_controller_spec.rb
+++ b/test/integration/compute_controller/serverspec/compute_controller_spec.rb
@@ -32,7 +32,8 @@ end
   'instance_usage_audit = True',
   'instance_usage_audit_period = hour',
   'notify_on_state_change = vm_and_task_state',
-  'resume_guests_state_on_host_boot = True'
+  'resume_guests_state_on_host_boot = True',
+  'block_device_allocate_retries = 120'
 ].each do |s|
   describe file('/etc/nova/nova.conf') do
     its(:content) do


### PR DESCRIPTION
This is to work around and issue we ran into with RT:29860 where it was taking
too long for the block device to be created.