### PR TITLE
The default shutdown timeout is 300s (5m), lower to 120s (1.5m)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,7 +44,8 @@ default['osl-openstack']['nova_ssl_dir'] = '/etc/nova/pki'
 default['osl-openstack']['libvirt_guests'] = {
   'on_boot' => 'ignore',
   'on_shutdown' => 'shutdown',
-  'parallel_shutdown' => '25'
+  'parallel_shutdown' => '25',
+  'shutdown_timeout' => '120'
 }
 default['osl-openstack']['novnc'] = {
   'use_ssl' => true,

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -37,14 +37,21 @@ describe 'osl-openstack::compute' do
     expect(chef_run).to create_template('/etc/sysconfig/libvirt-guests')
       .with(
         variables: {
-          libvirt_guests: { 'on_boot' => 'ignore', 'on_shutdown' => 'shutdown', 'parallel_shutdown' => '25' }
+          libvirt_guests: {
+            'on_boot' => 'ignore',
+            'on_shutdown' =>
+            'shutdown',
+            'parallel_shutdown' => '25',
+            'shutdown_timeout' => '120'
+          }
         }
       )
   end
   [
     /^ON_BOOT=ignore$/,
     /^ON_SHUTDOWN=shutdown$/,
-    /^PARALLEL_SHUTDOWN=25$/
+    /^PARALLEL_SHUTDOWN=25$/,
+    /^SHUTDOWN_TIMEOUT=120$/
   ].each do |line|
     it do
       expect(chef_run).to render_file('/etc/sysconfig/libvirt-guests').with_content(line)

--- a/test/integration/compute/serverspec/compute_spec.rb
+++ b/test/integration/compute/serverspec/compute_spec.rb
@@ -21,6 +21,7 @@ describe file('/etc/sysconfig/libvirt-guests') do
   its(:content) { should match(/^ON_BOOT=ignore$/) }
   its(:content) { should match(/^ON_SHUTDOWN=shutdown$/) }
   its(:content) { should match(/^PARALLEL_SHUTDOWN=25$/) }
+  its(:content) { should match(/^SHUTDOWN_TIMEOUT=120$/) }
 end
 
 describe file('/var/lib/nova/.ssh/authorized_keys') do


### PR DESCRIPTION
Most VMs should shutdown within 120 seconds in my opinion and waiting for 5
minutes to shutdown a machine because of one VM is simply too much to ask so
let's lower it.