### PR TITLE
Ceph integration

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,7 @@ provisioner:
     base:
       packages: []
     osl-openstack:
+      ceph: true
       database_suffix: x86
       databag_prefix: x86
       endpoint_hostname: controller.example.com
@@ -24,6 +25,14 @@ provisioner:
     openstack:
       secret:
         key_path: "/tmp/kitchen/encrypted_data_bag_secret"
+    ceph:
+      network:
+        public:
+          cidr:
+            - '10.1.100.0/24'
+        cluster:
+          cidr:
+            - '10.1.100.0/24'
     mariadb:
       server_root_password: "rootpass"
       forbid_remote_root: false
@@ -41,7 +50,9 @@ provisioner:
 suites:
   - name: default
     run_list:
+      - recipe[openstack_test::ceph_setup]
       - recipe[osl-openstack::default]
+      - recipe[openstack_test::ceph]
   - name: mon
     provisioner: chef_solo
     run_list:

--- a/Berksfile
+++ b/Berksfile
@@ -5,8 +5,11 @@ solver :ruby, :required
 # OSL Base deps
 cookbook 'aliases', git: 'git@github.com:osuosl-cookbooks/aliases'
 cookbook 'base', git: 'git@github.com:osuosl-cookbooks/base'
+cookbook 'ceph-chef', github: 'osuosl-cookbooks/ceph-chef'
 cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
 cookbook 'munin', git: 'git@github.com:osuosl-cookbooks/munin'
+cookbook 'osl-ceph', git: 'git@github.com:osuosl-cookbooks/osl-ceph'
+cookbook 'osl-docker', git: 'git@github.com:osuosl-cookbooks/osl-docker'
 cookbook 'osl-nrpe', git: 'git@github.com:osuosl-cookbooks/osl-nrpe'
 cookbook 'osl-apache', git: 'git@github.com:osuosl-cookbooks/osl-apache'
 cookbook 'osl-munin', git: 'git@github.com:osuosl-cookbooks/osl-munin'
@@ -21,18 +24,18 @@ cookbook 'ibm-power', git: 'git@github.com:osuosl-cookbooks/ibm-power.git'
 cookbook 'openstackclient', github: 'cloudbau/cookbook-openstackclient'
 
 # WIP patches
-# %w(
-# ).each do |cb|
-#   cookbook "openstack-#{cb}",
-#            github: "osuosl-cookbooks/cookbook-openstack-#{cb}",
-#            branch: 'stable/newton'
-# end
+%w(
+  compute
+).each do |cb|
+  cookbook "openstack-#{cb}",
+           github: "osuosl-cookbooks/cookbook-openstack-#{cb}",
+           branch: 'stable/newton'
+end
 
 # Openstack deps
 %w(
   block-storage
   common
-  compute
   dashboard
   identity
   image

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,11 +20,22 @@ default['osl-openstack']['data_bags'] = %w(
   service_passwords
   user_passwords
 )
+default['osl-openstack']['credentials']['ceph'] = {}
+default['osl-openstack']['ceph'] = false
+default['osl-openstack']['ceph_databag'] = 'ceph'
+default['osl-openstack']['ceph_item'] = 'openstack'
 default['osl-openstack']['database_suffix'] = nil
 default['osl-openstack']['databag_prefix'] = nil
+default['osl-openstack']['compute']['rbd_store_pool'] = 'vms'
 default['osl-openstack']['cinder']['iscsi_role'] = nil
 default['osl-openstack']['cinder']['iscsi_ips'] = []
+default['osl-openstack']['block']['rbd_store_pool'] = 'volumes'
+default['osl-openstack']['block']['rbd_store_user'] = 'cinder'
+default['osl-openstack']['block_backup']['rbd_store_pool'] = 'backups'
+default['osl-openstack']['block_backup']['rbd_store_user'] = 'cinder-backup'
 default['osl-openstack']['image']['glance_vol'] = nil
+default['osl-openstack']['image']['rbd_store_pool'] = 'images'
+default['osl-openstack']['image']['rbd_store_user'] = 'glance'
 default['osl-openstack']['endpoint_hostname'] = nil
 default['osl-openstack']['network_hostname'] = nil
 default['osl-openstack']['db_hostname'] = nil

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,0 +1,17 @@
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/MethodLength
+def openstack_credential_secrets
+  Chef::EncryptedDataBagItem.load(
+    node['osl-openstack']['ceph_databag'],
+    node['osl-openstack']['ceph_item']
+  )
+rescue Net::HTTPServerException => e
+  databag = "#{node['osl-openstack']['ceph_databag']}:#{node['osl-openstack']['ceph_item']}"
+  if e.response.code == '404'
+    Chef::Log.warn("Could not find databag '#{databag}'; falling back to default attributes.")
+    node['osl-openstack']['credentials']
+  else
+    Chef::Log.fatal("Unable to load databag '#{databag}'; exiting. Please fix the databag and try again.")
+    raise
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ version          '3.1.7'
   openstack-dashboard openstack-identity openstack-integration-test
   openstack-image openstack-network openstack-ops-database
   openstack-ops-messaging openstack-orchestration openstack-telemetry selinux
-  sudo yum-qemu-ev ibm-power apache2 yum-epel yum-kernel-osuosl}.each do |cb|
+  sudo yum-qemu-ev ibm-power apache2 yum-epel yum-kernel-osuosl osl-ceph}.each do |cb|
   depends cb
 end
 

--- a/networks-ppc.sh
+++ b/networks-ppc.sh
@@ -2,14 +2,14 @@ set -x
 neutron net-create public --shared --provider:physical_network public \
   --provider:network_type flat
 neutron subnet-create public 140.211.168.0/24 --name public \
-  --allocation-pool start=140.211.168.90,end=140.211.168.108 \
+  --allocation-pool start=140.211.168.45,end=140.211.168.48 \
     --dns-nameserver 140.211.166.130 --dns-nameserver 140.211.166.131 \
     --gateway 140.211.168.1
-neutron net-create vlan42 --shared --provider:physical_network vlan42 \
-  --provider:network_type flat
-neutron subnet-create vlan42 10.1.100.0/24 --name vlan42 \
-  --allocation-pool start=10.1.100.51,end=10.1.100.100 \
-    --dns-nameserver 140.211.166.130 --gateway 10.1.100.1
+#neutron net-create backend --shared --provider:physical_network backend \
+#  --provider:network_type flat
+#neutron subnet-create backend 10.1.100.0/24 --name backend \
+#  --allocation-pool start=10.1.100.51,end=10.1.100.100 \
+#    --dns-nameserver 140.211.166.130 --gateway 10.1.100.1
 neutron net-create private
 neutron subnet-create private 192.168.30.0/24 --name private \
   --dns-nameserver 8.8.8.8 --gateway 192.168.30.1

--- a/recipes/_block_ceph.rb
+++ b/recipes/_block_ceph.rb
@@ -1,0 +1,35 @@
+secrets = openstack_credential_secrets
+
+package 'openstack-cinder'
+
+group 'ceph' do
+  append true
+  members %w(cinder)
+  action :modify
+  notifies :restart, 'service[cinder-volume]', :immediately if node.recipe?('openstack-block-storage::volume')
+end
+
+template "/etc/ceph/ceph.client.#{node['osl-openstack']['block']['rbd_store_user']}.keyring" do
+  source 'ceph.client.keyring.erb'
+  owner node['ceph']['owner']
+  group node['ceph']['group']
+  sensitive true
+  not_if { secrets['ceph']['block_token'].nil? }
+  variables(
+    ceph_user: node['osl-openstack']['block']['rbd_store_user'],
+    ceph_token: secrets['ceph']['block_token']
+  )
+  notifies :restart, 'service[cinder-volume]', :immediately if node.recipe?('openstack-block-storage::volume')
+end
+
+template "/etc/ceph/ceph.client.#{node['osl-openstack']['block_backup']['rbd_store_user']}.keyring" do
+  source 'ceph.client.keyring.erb'
+  owner node['ceph']['owner']
+  group node['ceph']['group']
+  sensitive true
+  not_if { secrets['ceph']['block_backup_token'].nil? }
+  variables(
+    ceph_user: node['osl-openstack']['block_backup']['rbd_store_user'],
+    ceph_token: secrets['ceph']['block_backup_token']
+  )
+end

--- a/recipes/block_storage.rb
+++ b/recipes/block_storage.rb
@@ -34,3 +34,4 @@ include_recipe 'firewall::iscsi'
 include_recipe 'osl-openstack'
 include_recipe 'openstack-block-storage::volume'
 include_recipe 'openstack-block-storage::identity_registration'
+include_recipe 'osl-openstack::_block_ceph' if node['osl-openstack']['ceph']

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -82,7 +82,7 @@ if node['osl-openstack']['ceph']
 
   group 'ceph' do
     append true
-    members %w(nova)
+    members %w(nova qemu)
     action :modify
     notifies :restart, 'service[nova-compute]', :immediately
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -154,10 +154,11 @@ end
 
 node.default['openstack']['block-storage']['conf'].tap do |conf|
   conf['oslo_messaging_notifications']['driver'] = 'messagingv2'
-  conf['DEFAULT']['volume_group'] = 'openstack'
-  conf['DEFAULT']['volume_clear_size'] = 256
+  conf['lvm']['volume_driver'] = 'cinder.volume.drivers.lvm.LVMVolumeDriver'
+  conf['lvm']['volume_group'] = 'openstack'
+  conf['lvm']['volume_clear_size'] = 256
   if node['osl-openstack']['ceph']
-    conf['DEFAULT']['enabled_backends'] = 'ceph'
+    conf['DEFAULT']['enabled_backends'] = 'ceph,lvm'
     conf['DEFAULT']['backup_driver'] = 'cinder.backup.drivers.ceph'
     conf['DEFAULT']['backup_ceph_conf'] = '/etc/ceph/ceph.conf'
     conf['DEFAULT']['backup_ceph_user'] = node['osl-openstack']['block_backup']['rbd_store_user']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,6 +48,7 @@ end
 node.default['openstack']['image_api']['conf'].tap do |conf|
   if node['osl-openstack']['ceph']
     conf['DEFAULT']['show_image_direct_url'] = true
+    conf['DEFAULT']['show_multiple_locations'] = true
     conf['paste_deploy']['flavor'] = 'keystone'
     conf['glance_store']['stores'] = 'rbd,file,http'
     conf['glance_store']['default_store'] = 'rbd'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -154,11 +154,10 @@ end
 
 node.default['openstack']['block-storage']['conf'].tap do |conf|
   conf['oslo_messaging_notifications']['driver'] = 'messagingv2'
-  conf['lvm']['volume_driver'] = 'cinder.volume.drivers.lvm.LVMVolumeDriver'
-  conf['lvm']['volume_group'] = 'openstack'
-  conf['lvm']['volume_clear_size'] = 256
+  conf['DEFAULT']['volume_group'] = 'openstack'
+  conf['DEFAULT']['volume_clear_size'] = 256
   if node['osl-openstack']['ceph']
-    conf['DEFAULT']['enabled_backends'] = 'ceph,lvm'
+    conf['DEFAULT']['enabled_backends'] = 'ceph'
     conf['DEFAULT']['backup_driver'] = 'cinder.backup.drivers.ceph'
     conf['DEFAULT']['backup_ceph_conf'] = '/etc/ceph/ceph.conf'
     conf['DEFAULT']['backup_ceph_user'] = node['osl-openstack']['block_backup']['rbd_store_user']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,6 +45,18 @@ node.default['openstack']['identity']['ssl'].tap do |conf|
   conf['keyfile'] = '/etc/pki/tls/private/wildcard.key'
   conf['chainfile'] = '/etc/pki/tls/certs/wildcard-bundle.crt'
 end
+node.default['openstack']['image_api']['conf'].tap do |conf|
+  if node['osl-openstack']['ceph']
+    conf['DEFAULT']['show_image_direct_url'] = true
+    conf['paste_deploy']['flavor'] = 'keystone'
+    conf['glance_store']['stores'] = 'rbd,file,http'
+    conf['glance_store']['default_store'] = 'rbd'
+    conf['glance_store']['rbd_store_pool'] = node['osl-openstack']['image']['rbd_store_pool']
+    conf['glance_store']['rbd_store_user'] = node['osl-openstack']['image']['rbd_store_user']
+    conf['glance_store']['rbd_store_ceph_conf'] = '/etc/ceph/ceph.conf'
+    conf['glance_store']['rbd_store_chunk_size'] = 8
+  end
+end
 node.default['openstack']['compute']['conf'].tap do |conf|
   conf['DEFAULT']['scheduler_default_filters'] =
     %w(
@@ -61,7 +73,29 @@ node.default['openstack']['compute']['conf'].tap do |conf|
   conf['DEFAULT']['disk_allocation_ratio'] = 1.5
   conf['DEFAULT']['resume_guests_state_on_host_boot'] = 'True'
   conf['DEFAULT']['block_device_allocate_retries'] = 120
-  conf['libvirt']['disk_cachemodes'] = 'file=writeback,block=none'
+  if node['osl-openstack']['ceph']
+    conf['libvirt']['disk_cachemodes'] = 'network=writeback'
+    conf['libvirt']['force_raw_images'] = true
+    conf['libvirt']['hw_disk_discard'] = 'unmap'
+    conf['libvirt']['images_rbd_ceph_conf'] = '/etc/ceph/ceph.conf'
+    conf['libvirt']['images_rbd_pool'] = node['osl-openstack']['compute']['rbd_store_pool']
+    conf['libvirt']['images_type'] = 'rbd'
+    conf['libvirt']['inject_key'] = false
+    conf['libvirt']['inject_partition'] = '-2'
+    conf['libvirt']['inject_password'] = false
+    conf['libvirt']['live_migration_flag'] =
+      %w(
+        VIR_MIGRATE_UNDEFINE_SOURCE
+        VIR_MIGRATE_PEER2PEER
+        VIR_MIGRATE_LIVE
+        VIR_MIGRATE_PERSIST_DEST
+        VIR_MIGRATE_TUNNELLED
+      ).join(',')
+    conf['libvirt']['rbd_secret_uuid'] = node['ceph']['fsid-secret']
+    conf['libvirt']['rbd_user'] = node['osl-openstack']['block']['rbd_store_user']
+  else
+    conf['libvirt']['disk_cachemodes'] = 'file=writeback,block=none'
+  end
 end
 node.default['openstack']['network'].tap do |conf|
   conf['conf']['DEFAULT']['service_plugins'] =
@@ -110,13 +144,6 @@ node.default['openstack']['dashboard'].tap do |conf|
   conf['ssl']['key'] = 'wildcard.key'
   conf['ssl']['cert'] = 'wildcard.pem'
   conf['ssl']['chain'] = 'wildcard-bundle.crt'
-  conf['misc_local_settings'] = {
-    'LAUNCH_INSTANCE_DEFAULTS' => {
-      create_volume: false, # Not available until Pike
-      disable_volume: true,
-      disable_volume_snapshot: true
-    }
-  }
 end
 
 node.default['openstack']['telemetry']['conf'].tap do |conf|
@@ -128,6 +155,29 @@ node.default['openstack']['block-storage']['conf'].tap do |conf|
   conf['oslo_messaging_notifications']['driver'] = 'messagingv2'
   conf['DEFAULT']['volume_group'] = 'openstack'
   conf['DEFAULT']['volume_clear_size'] = 256
+  if node['osl-openstack']['ceph']
+    conf['DEFAULT']['enabled_backends'] = 'ceph'
+    conf['DEFAULT']['backup_driver'] = 'cinder.backup.drivers.ceph'
+    conf['DEFAULT']['backup_ceph_conf'] = '/etc/ceph/ceph.conf'
+    conf['DEFAULT']['backup_ceph_user'] = node['osl-openstack']['block_backup']['rbd_store_user']
+    conf['DEFAULT']['backup_ceph_chunk_size'] = 134_217_728
+    conf['DEFAULT']['backup_ceph_pool'] = node['osl-openstack']['block_backup']['rbd_store_pool']
+    conf['DEFAULT']['backup_ceph_stripe_unit'] = 0
+    conf['DEFAULT']['backup_ceph_stripe_count'] = 0
+    conf['DEFAULT']['restore_discard_excess_bytes'] = true
+    conf['ceph']['volume_driver'] = 'cinder.volume.drivers.rbd.RBDDriver'
+    conf['ceph']['volume_backend_name'] = 'ceph'
+    conf['ceph']['rbd_pool'] = node['osl-openstack']['block']['rbd_store_pool']
+    conf['ceph']['rbd_ceph_conf'] = '/etc/ceph/ceph.conf'
+    conf['ceph']['rbd_flatten_volume_from_snapshot'] = false
+    conf['ceph']['rbd_max_clone_depth'] = 5
+    conf['ceph']['rbd_store_chunk_size'] = 4
+    conf['ceph']['rados_connect_timeout'] = -1
+    conf['ceph']['rbd_user'] = node['osl-openstack']['block']['rbd_store_user']
+    conf['ceph']['rbd_secret_uuid'] = node['ceph']['fsid-secret']
+    conf['libvirt']['rbd_user'] = node['osl-openstack']['block']['rbd_store_user']
+    conf['libvirt']['rbd_secret_uuid'] = node['ceph']['fsid-secret']
+  end
 end
 
 node.default['openstack']['block-storage']['platform']['cinder_volume_packages'] = %w(qemu-img-ev)
@@ -361,6 +411,7 @@ include_recipe 'openstack-common::sysctl'
 include_recipe 'openstack-identity::openrc'
 include_recipe 'build-essential'
 include_recipe 'openstack-common::client'
+include_recipe 'osl-ceph' if node['osl-openstack']['ceph']
 
 edit_resource(:python_runtime, '2') do
   provider :system

--- a/spec/block_storage_controller_spec.rb
+++ b/spec/block_storage_controller_spec.rb
@@ -31,19 +31,12 @@ describe 'osl-openstack::block_storage_controller' do
       /^my_ip = 10.0.0.2$/,
       %r{^glance_api_servers = http://10.0.0.10:9292},
       /^osapi_volume_listen = 10.0.0.2$/,
+      /^volume_group = openstack$/,
+      /^volume_clear_size = 256$/,
       %r{^transport_url = rabbit://guest:mq-pass@10.0.0.10:5672$}
     ].each do |line|
       it do
         expect(chef_run).to render_config_file(file.name).with_section_content('DEFAULT', line)
-      end
-    end
-    [
-      /^volume_group = openstack$/,
-      /^volume_clear_size = 256$/,
-      /^volume_driver = cinder.volume.drivers.lvm.LVMVolumeDriver$/
-    ].each do |line|
-      it do
-        expect(chef_run).to render_config_file(file.name).with_section_content('lvm', line)
       end
     end
     it do
@@ -105,7 +98,7 @@ describe 'osl-openstack::block_storage_controller' do
       include_context 'common_stubs'
       include_context 'ceph_stubs'
       [
-        /^enabled_backends = ceph,lvm$/,
+        /^enabled_backends = ceph$/,
         /^backup_driver = cinder.backup.drivers.ceph$/,
         %r{^backup_ceph_conf = /etc/ceph/ceph.conf$},
         /^backup_ceph_user = cinder-backup$/,

--- a/spec/block_storage_controller_spec.rb
+++ b/spec/block_storage_controller_spec.rb
@@ -31,12 +31,19 @@ describe 'osl-openstack::block_storage_controller' do
       /^my_ip = 10.0.0.2$/,
       %r{^glance_api_servers = http://10.0.0.10:9292},
       /^osapi_volume_listen = 10.0.0.2$/,
-      /^volume_group = openstack$/,
-      /^volume_clear_size = 256$/,
       %r{^transport_url = rabbit://guest:mq-pass@10.0.0.10:5672$}
     ].each do |line|
       it do
         expect(chef_run).to render_config_file(file.name).with_section_content('DEFAULT', line)
+      end
+    end
+    [
+      /^volume_group = openstack$/,
+      /^volume_clear_size = 256$/,
+      /^volume_driver = cinder.volume.drivers.lvm.LVMVolumeDriver$/
+    ].each do |line|
+      it do
+        expect(chef_run).to render_config_file(file.name).with_section_content('lvm', line)
       end
     end
     it do
@@ -98,7 +105,7 @@ describe 'osl-openstack::block_storage_controller' do
       include_context 'common_stubs'
       include_context 'ceph_stubs'
       [
-        /^enabled_backends = ceph$/,
+        /^enabled_backends = ceph,lvm$/,
         /^backup_driver = cinder.backup.drivers.ceph$/,
         %r{^backup_ceph_conf = /etc/ceph/ceph.conf$},
         /^backup_ceph_user = cinder-backup$/,

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -131,7 +131,7 @@ Host *
       expect(chef_run).to modify_group('ceph')
         .with(
           append: true,
-          members: %w(nova)
+          members: %w(nova qemu)
         )
     end
     it do

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -30,6 +30,10 @@ describe 'osl-openstack::compute' do
     end
   end
 
+  it do
+    expect(chef_run).to_not include_recipe('osl-openstack::_block_ceph')
+  end
+
   it 'loads tun module' do
     expect(chef_run).to load_kernel_module('tun')
   end
@@ -94,6 +98,115 @@ Host *
   UserKnownHostsFile /dev/null
         EOL
       )
+  end
+
+  context 'Set ceph' do
+    let(:runner) do
+      ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
+        node.set['osl-openstack']['ceph'] = true
+        node.automatic['filesystem2']['by_mountpoint']
+      end
+    end
+    let(:node) { runner.node }
+    cached(:chef_run) { runner.converge(described_recipe) }
+    include_context 'common_stubs'
+    include_context 'ceph_stubs'
+    before do
+      stub_command('virsh secret-list | grep 8102bb29-f48b-4f6e-81d7-4c59d80ec6b8').and_return(false)
+      stub_command('virsh secret-get-value 8102bb29-f48b-4f6e-81d7-4c59d80ec6b8 | grep block_token')
+        .and_return(false)
+    end
+    %w(
+      /var/run/ceph/guests
+      /var/log/ceph
+    ).each do |d|
+      it do
+        expect(chef_run).to create_directory(d).with(owner: 'qemu', group: 'libvirt')
+      end
+    end
+    it do
+      expect(chef_run).to include_recipe('osl-openstack::_block_ceph')
+    end
+    it do
+      expect(chef_run).to modify_group('ceph')
+        .with(
+          append: true,
+          members: %w(nova)
+        )
+    end
+    it do
+      expect(chef_run.group('ceph')).to notify('service[nova-compute]').to(:restart).immediately
+    end
+    it do
+      expect(chef_run.group('ceph')).to_not notify('service[cinder-volume]').to(:restart).immediately
+    end
+    it do
+      expect(chef_run.template('/etc/ceph/ceph.client.cinder.keyring')).to_not notify('service[cinder-volume]')
+        .to(:restart).immediately
+    end
+    it do
+      expect(chef_run).to create_template('/var/chef/cache/secret.xml')
+        .with(
+          source: 'secret.xml.erb',
+          user: 'root',
+          group: 'root',
+          mode: '00600',
+          variables: {
+            uuid: '8102bb29-f48b-4f6e-81d7-4c59d80ec6b8',
+            client_name: 'cinder'
+          }
+        )
+    end
+    it do
+      expect(chef_run).to run_execute('virsh secret-define --file /var/chef/cache/secret.xml')
+    end
+    it do
+      expect(chef_run).to run_execute('update virsh ceph secret')
+        .with(
+          command: 'virsh secret-set-value --secret 8102bb29-f48b-4f6e-81d7-4c59d80ec6b8 --base64 block_token',
+          sensitive: true
+        )
+    end
+    it do
+      expect(chef_run).to delete_file('/var/chef/cache/secret.xml')
+    end
+    [
+      %r{^admin socket = /var/run/ceph/guests/\$cluster-\$type.\$id.\$pid.\$cctid.asok$},
+      /^rbd concurrent management ops = 20$/,
+      /^rbd cache = true$/,
+      /^rbd cache writethrough until flush = true$/,
+      %r{log file = /var/log/ceph/qemu-guest-\$pid.log$}
+    ].each do |line|
+      it do
+        expect(chef_run).to render_config_file('/etc/ceph/ceph.conf').with_section_content('client', line)
+      end
+    end
+    context 'virsh secret exists' do
+      let(:runner) do
+        ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
+          node.set['osl-openstack']['ceph'] = true
+          node.automatic['filesystem2']['by_mountpoint']
+        end
+      end
+      let(:node) { runner.node }
+      cached(:chef_run) { runner.converge(described_recipe) }
+      include_context 'common_stubs'
+      include_context 'ceph_stubs'
+      before do
+        stub_command('virsh secret-list | grep 8102bb29-f48b-4f6e-81d7-4c59d80ec6b8').and_return(true)
+        stub_command('virsh secret-get-value 8102bb29-f48b-4f6e-81d7-4c59d80ec6b8 | grep block_token')
+          .and_return(true)
+      end
+      it do
+        expect(chef_run).to_not create_template('/var/chef/cache/secret.xml')
+      end
+      it do
+        expect(chef_run).to_not run_execute('virsh secret-define --file /var/chef/cache/secret.xml')
+      end
+      it do
+        expect(chef_run).to_not run_execute('update virsh ceph secret')
+      end
+    end
   end
 
   context 'setting arch to ppc64le' do

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -42,15 +42,6 @@ describe 'osl-openstack::dashboard', dashboard: true do
     expect(chef_run.node['openstack']['dashboard']['ssl'] \
       ['chain']).to eq('wildcard-bundle.crt')
   end
-  it do
-    expect(chef_run).to render_file('/etc/openstack-dashboard/local_settings')
-      .with_content(/
-LAUNCH_INSTANCE_DEFAULTS = {
-  'create_volume': 'false',
-  'disable_volume': 'true',
-  'disable_volume_snapshot': 'true',
-}/)
-  end
   context 'Secret files already exist' do
     let(:chef_run) { runner.converge(described_recipe) }
     it 'Set secret key lock file permissions' do

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -77,7 +77,8 @@ describe 'osl-openstack::image', image: true do
             notify('service[glance-api]').to(:restart)
         end
         [
-          /^show_image_direct_url = true$/
+          /^show_image_direct_url = true$/,
+          /^show_multiple_locations = true$/
         ].each do |line|
           it do
             expect(chef_run).to render_config_file(file.name).with_section_content('DEFAULT', line)

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -37,6 +37,91 @@ describe 'osl-openstack::image', image: true do
           expect(chef_run).to render_config_file(file.name).with_section_content('DEFAULT', line)
         end
       end
+      context 'Set ceph' do
+        next unless f == 'api'
+        let(:runner) do
+          ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
+            node.set['osl-openstack']['ceph'] = true
+            node.automatic['filesystem2']['by_mountpoint']
+          end
+        end
+        let(:node) { runner.node }
+        cached(:chef_run) { runner.converge(described_recipe) }
+        include_context 'common_stubs'
+        include_context 'ceph_stubs'
+        it do
+          expect(chef_run).to modify_group('ceph')
+            .with(
+              append: true,
+              members: %w(glance)
+            )
+        end
+        it do
+          expect(chef_run.group('ceph')).to notify('service[glance-api]').to(:restart).immediately
+        end
+        it do
+          expect(chef_run).to create_template('/etc/ceph/ceph.client.glance.keyring')
+            .with(
+              source: 'ceph.client.keyring.erb',
+              owner: 'ceph',
+              group: 'ceph',
+              sensitive: true,
+              variables: {
+                ceph_user: 'glance',
+                ceph_token: 'image_token'
+              }
+            )
+        end
+        it do
+          expect(chef_run.template('/etc/ceph/ceph.client.glance.keyring')).to \
+            notify('service[glance-api]').to(:restart)
+        end
+        [
+          /^show_image_direct_url = true$/
+        ].each do |line|
+          it do
+            expect(chef_run).to render_config_file(file.name).with_section_content('DEFAULT', line)
+          end
+        end
+        [
+          /^flavor = keystone$/
+        ].each do |line|
+          it do
+            expect(chef_run).to render_config_file(file.name).with_section_content('paste_deploy', line)
+          end
+        end
+        [
+          /^default_store = rbd$/,
+          /^stores = rbd,file,http$/,
+          /^rbd_store_pool = images$/,
+          /^rbd_store_user = glance$/,
+          %r{^rbd_store_ceph_conf = /etc/ceph/ceph.conf$},
+          /^rbd_store_chunk_size = 8$/
+        ].each do |line|
+          it do
+            expect(chef_run).to render_config_file(file.name).with_section_content('glance_store', line)
+          end
+        end
+        context 'no image_token' do
+          next unless f == 'api'
+          let(:runner) do
+            ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
+              node.set['osl-openstack']['ceph'] = true
+              node.automatic['filesystem2']['by_mountpoint']
+            end
+          end
+          let(:node) { runner.node }
+          cached(:chef_run) { runner.converge(described_recipe) }
+          include_context 'common_stubs'
+          include_context 'ceph_stubs'
+          before do
+            node.set['osl-openstack']['credentials']['ceph']['image_token'] = nil
+          end
+          it do
+            expect(chef_run).to_not create_template('/etc/ceph/ceph.client.glance.keyring')
+          end
+        end
+      end
 
       context 'Set bind_service' do
         cached(:chef_run) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,65 @@ shared_context 'common_stubs' do
     node.set['osl-openstack']['db_hostname'] = '10.0.0.10'
     node.set['osl-openstack']['database_suffix'] = 'x86'
     node.set['osl-openstack']['databag_suffix'] = 'x86'
+    node.set['osl-openstack']['credentials']['ceph']['image_token'] = 'image_token'
+    node.set['osl-openstack']['credentials']['ceph']['block_token'] = 'block_token'
+    node.set['osl-openstack']['credentials']['ceph']['block_backup_token'] = 'block_backup_token'
+    node.set['ceph']['fsid-secret'] = '8102bb29-f48b-4f6e-81d7-4c59d80ec6b8'
     node.automatic['filesystem2']['by_mountpoint']
+  end
+end
+
+shared_context 'ceph_stubs' do
+  before do
+    stub_command('test -s /etc/yum.repos.d/ceph.repo')
+    stub_command('test -s /lib/lsb/init-functions')
+    stub_command('getenforce | grep \'Permissive|Disabled\'')
+    stub_command('test -f /etc/ceph')
+    stub_command('test -s /etc/ceph/ceph.mon.keyring')
+    stub_command('test -s /etc/ceph/ceph.client.admin.keyring')
+    stub_command('grep \'admin\' /etc/ceph/ceph.mon.keyring')
+    stub_command('test -s /var/lib/ceph/mon/ceph-Fauxhai/keyring')
+    stub_command('test -f /var/lib/ceph/mon/ceph-Fauxhai/done')
+    stub_command('test -d /var/lib/ceph/mgr/ceph-Fauxhai')
+    stub_command('test -s /var/lib/ceph/mgr/ceph-Fauxhai/keyring')
+    stub_command('test -d /etc/ceph/scripts')
+    stub_command('test -f /etc/ceph/scripts/ceph_journal.sh')
+    stub_command('test -s /var/lib/ceph/bootstrap-osd/ceph.keyring')
+    stub_search('node', 'tags:ceph-mon').and_return(
+      [
+        {
+          fqdn: 'ceph-mon.example.org',
+          roles: 'search-ceph-mon',
+          ceph: {
+            'fsid-secret' => '8102bb29-f48b-4f6e-81d7-4c59d80ec6b8'
+          },
+          network: {
+            interfaces: {
+              eth0: {
+                addresses: {
+                  '10.121.1.1' => {
+                    family: 'inet',
+                    broadcast: '255.255.255.0'
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    )
+    stub_search('node', 'tags:ceph-rgw').and_return([{}])
+    stub_search('node', 'tags:ceph-rbd').and_return([{}])
+    stub_search('node', 'tags:ceph-admin').and_return([{}])
+    stub_search('node', 'tags:ceph-osd').and_return([{}])
+    stub_search('node', 'tags:ceph-mds').and_return([{}])
+    stub_search('node', 'tags:ceph-restapi').and_return([{}])
+    allow(Chef::EncryptedDataBagItem).to receive(:load)
+      .with('ceph', 'openstack')
+      .and_raise(Net::HTTPServerException.new(
+                   'ceph databag not found',
+                   Net::HTTPResponse.new('1.1', '404', '')
+      ))
   end
 end
 

--- a/templates/default/ceph.client.keyring.erb
+++ b/templates/default/ceph.client.keyring.erb
@@ -1,0 +1,2 @@
+[client.<%= @ceph_user %>]
+    key = <%= @ceph_token %>

--- a/templates/default/secret.xml.erb
+++ b/templates/default/secret.xml.erb
@@ -1,0 +1,6 @@
+<secret ephemeral='no' private='no'>
+  <uuid><%= @uuid -%></uuid>
+  <usage type='ceph'>
+    <name>client.<%= @client_name -%> secret</name>
+  </usage>
+</secret>

--- a/test/cookbooks/openstack_test/libraries/helper.rb
+++ b/test/cookbooks/openstack_test/libraries/helper.rb
@@ -19,27 +19,6 @@ def ceph_demo_mon_key
   mon_client['mon.']['key']
 end
 
-def ceph_demo_glance_key
-  require 'inifile'
-  wait_for_file('/etc/ceph/ceph.client.glance.keyring')
-  glance_client = IniFile.load('/etc/ceph/ceph.client.glance.keyring')
-  glance_client['client.glance']['key']
-end
-
-def ceph_demo_cinder_key
-  require 'inifile'
-  wait_for_file('/etc/ceph/ceph.client.cinder.keyring')
-  cinder_client = IniFile.load('/etc/ceph/ceph.client.cinder.keyring')
-  cinder_client['client.cinder']['key']
-end
-
-def ceph_demo_cinder_backup_key
-  require 'inifile'
-  wait_for_file('/etc/ceph/ceph.client.cinder-backup.keyring')
-  cinder_backup_client = IniFile.load('/etc/ceph/ceph.client.cinder-backup.keyring')
-  cinder_backup_client['client.cinder-backup']['key']
-end
-
 def wait_for_file(file)
   sleep(1) until File.exist?(file)
 end

--- a/test/cookbooks/openstack_test/libraries/helper.rb
+++ b/test/cookbooks/openstack_test/libraries/helper.rb
@@ -1,0 +1,45 @@
+def ceph_demo_fsid
+  require 'inifile'
+  wait_for_file('/etc/ceph-docker/ceph.conf')
+  ceph_conf = IniFile.load('/etc/ceph-docker/ceph.conf')
+  ceph_conf['global']['fsid']
+end
+
+def ceph_demo_admin_key
+  require 'inifile'
+  wait_for_file('/etc/ceph-docker/ceph.client.admin.keyring')
+  admin_client = IniFile.load('/etc/ceph-docker/ceph.client.admin.keyring')
+  admin_client['client.admin']['key']
+end
+
+def ceph_demo_mon_key
+  require 'inifile'
+  wait_for_file('/etc/ceph-docker/ceph.mon.keyring')
+  mon_client = IniFile.load('/etc/ceph-docker/ceph.mon.keyring')
+  mon_client['mon.']['key']
+end
+
+def ceph_demo_glance_key
+  require 'inifile'
+  wait_for_file('/etc/ceph/ceph.client.glance.keyring')
+  glance_client = IniFile.load('/etc/ceph/ceph.client.glance.keyring')
+  glance_client['client.glance']['key']
+end
+
+def ceph_demo_cinder_key
+  require 'inifile'
+  wait_for_file('/etc/ceph/ceph.client.cinder.keyring')
+  cinder_client = IniFile.load('/etc/ceph/ceph.client.cinder.keyring')
+  cinder_client['client.cinder']['key']
+end
+
+def ceph_demo_cinder_backup_key
+  require 'inifile'
+  wait_for_file('/etc/ceph/ceph.client.cinder-backup.keyring')
+  cinder_backup_client = IniFile.load('/etc/ceph/ceph.client.cinder-backup.keyring')
+  cinder_backup_client['client.cinder-backup']['key']
+end
+
+def wait_for_file(file)
+  sleep(1) until File.exist?(file)
+end

--- a/test/cookbooks/openstack_test/metadata.rb
+++ b/test/cookbooks/openstack_test/metadata.rb
@@ -5,6 +5,7 @@ license          'Apache 2.0'
 description      'Installs/Configures openstack_test'
 long_description ''
 version          '0.1.0'
+depends          'osl-ceph'
 depends          'osl-openstack'
-
+depends          'osl-docker'
 depends          'hostsfile'

--- a/test/cookbooks/openstack_test/recipes/ceph.rb
+++ b/test/cookbooks/openstack_test/recipes/ceph.rb
@@ -1,0 +1,38 @@
+%w(
+  volumes
+  images
+  backups
+  vms
+).each do |p|
+  ceph_chef_pool p do
+    pg_num 2
+    pgp_num 2
+  end
+  execute "rbd pool init #{p}"
+end
+
+execute 'client.glance' do
+  command 'ceph auth get-or-create client.glance mon \'profile rbd\' osd \'profile rbd pool=images\' ' \
+          '> /etc/ceph/ceph.client.glance.keyring'
+  creates '/etc/ceph/ceph.client.glance.keyring'
+end
+
+execute 'client.cinder' do
+  command 'ceph auth get-or-create client.cinder mon \'profile rbd\' osd \'profile rbd pool=volumes, ' \
+          'profile rbd pool=vms, profile rbd pool=images\' > /etc/ceph/ceph.client.cinder.keyring'
+  creates '/etc/ceph/ceph.client.cinder.keyring'
+end
+
+execute 'client.cinder-backup' do
+  command 'ceph auth get-or-create client.cinder-backup mon \'profile rbd\' osd \'profile rbd pool=backups\' ' \
+          '> /etc/ceph/ceph.client.cinder-backup.keyring'
+  creates '/etc/ceph/ceph.client.cinder-backup.keyring'
+end
+
+ruby_block 'set demo keys' do
+  block do
+    node.normal['osl-openstack']['credentials']['ceph']['image_token'] = ceph_demo_glance_key
+    node.normal['osl-openstack']['credentials']['ceph']['block_token'] = ceph_demo_cinder_key
+    node.normal['osl-openstack']['credentials']['ceph']['block_backup_token'] = ceph_demo_cinder_backup_key
+  end
+end

--- a/test/cookbooks/openstack_test/recipes/ceph_compute.rb
+++ b/test/cookbooks/openstack_test/recipes/ceph_compute.rb
@@ -1,0 +1,5 @@
+controller_node = search(:node, 'recipes:osl-openstack\:\:controller').first
+node.default['ceph']['fsid-secret'] = controller_node['ceph']['fsid-secret']
+node.default['ceph']['config']['global']['mon host'] = "#{controller_node['ipaddress']}:6789"
+
+include_recipe 'osl-ceph'

--- a/test/cookbooks/openstack_test/recipes/ceph_setup.rb
+++ b/test/cookbooks/openstack_test/recipes/ceph_setup.rb
@@ -10,13 +10,27 @@ docker_image 'osuosl/ceph' do
   action :pull
 end
 
+ceph_ip =
+  if node['ipaddress'] == '10.0.2.15'
+    '192.168.60.10'
+  else
+    node['ipaddress']
+  end
+
+ceph_network =
+  if node['ipaddress'] == '10.0.2.15'
+    '192.168.60.0/24'
+  else
+    '10.1.100.0/22'
+  end
+
 docker_container 'ceph' do
   repo 'osuosl/ceph'
   network_mode 'host'
   volumes ['/etc/ceph-docker:/etc/ceph']
   env [
-    "MON_IP=#{node['ipaddress']}",
-    'CEPH_PUBLIC_NETWORK=10.1.100.0/22',
+    "MON_IP=#{ceph_ip}",
+    "CEPH_PUBLIC_NETWORK=#{ceph_network}",
     'RGW_CIVETWEB_PORT=8000',
     'RESTAPI_PORT=8001'
   ]
@@ -28,7 +42,7 @@ ruby_block 'save ceph demo secrets' do
     ceph_chef_save_fsid_secret(ceph_demo_fsid)
     ceph_chef_save_admin_secret(ceph_demo_admin_key)
     ceph_chef_save_mon_secret(ceph_demo_mon_key)
-    node.default['ceph']['config']['global']['mon host'] = "#{node['ipaddress']}:6789"
+    node.default['ceph']['config']['global']['mon host'] = "#{ceph_ip}:6789"
   end
 end
 

--- a/test/cookbooks/openstack_test/recipes/ceph_setup.rb
+++ b/test/cookbooks/openstack_test/recipes/ceph_setup.rb
@@ -1,0 +1,45 @@
+node.override['osl-docker']['service'] = { misc_opts: '--live-restore' }
+
+chef_gem 'inifile' do
+  compile_time true
+end
+
+include_recipe 'osl-docker'
+
+docker_image 'osuosl/ceph' do
+  action :pull
+end
+
+docker_container 'ceph' do
+  repo 'osuosl/ceph'
+  network_mode 'host'
+  volumes ['/etc/ceph-docker:/etc/ceph']
+  env [
+    "MON_IP=#{node['ipaddress']}",
+    'CEPH_PUBLIC_NETWORK=10.1.100.0/22',
+    'RGW_CIVETWEB_PORT=8000',
+    'RESTAPI_PORT=8001'
+  ]
+  action :run
+end
+
+ruby_block 'save ceph demo secrets' do
+  block do
+    ceph_chef_save_fsid_secret(ceph_demo_fsid)
+    ceph_chef_save_admin_secret(ceph_demo_admin_key)
+    ceph_chef_save_mon_secret(ceph_demo_mon_key)
+    node.default['ceph']['config']['global']['mon host'] = "#{node['ipaddress']}:6789"
+  end
+end
+
+directory '/etc/ceph'
+
+%w(
+  ceph.client.admin.keyring
+  ceph.mon.keyring
+  monmap-ceph
+).each do |l|
+  link "/etc/ceph/#{l}" do
+    to "/etc/ceph-docker/#{l}"
+  end
+end

--- a/test/integration/block_storage/serverspec/block_storage_spec.rb
+++ b/test/integration/block_storage/serverspec/block_storage_spec.rb
@@ -15,6 +15,18 @@ set :backend, :exec
   end
 end
 
+describe user('cinder') do
+  it { should belong_to_group 'ceph' }
+end
+
+%w(cinder cinder-backup).each do |key|
+  describe file("/etc/ceph/ceph.client.#{key}.keyring") do
+    it { should be_owned_by 'ceph' }
+    it { should be_grouped_into 'ceph' }
+    its(:content) { should match(%r{key = [A-Za-z0-9+/].*==$}) }
+  end
+end
+
 # Make sure we can create a volume, it exists and delete it
 cinder = 'source /root/openrc && cinder '
 

--- a/test/integration/block_storage_controller/serverspec/block_storage_controller_spec.rb
+++ b/test/integration/block_storage_controller/serverspec/block_storage_controller_spec.rb
@@ -19,11 +19,11 @@ end
 describe file('/etc/cinder/cinder.conf') do
   its(:content) do
     should contain(/^volume_clear_size = 256$/)
-      .from(/^\[lvm\]$/).to(/^\[/)
+      .from(/^\[DEFAULT\]$/).to(/^\[/)
   end
   its(:content) do
     should contain(/^volume_group = openstack$/)
-      .from(/^\[lvm\]$/).to(/^\[/)
+      .from(/^\[DEFAULT\]$/).to(/^\[/)
   end
   its(:content) do
     should contain(/memcached_servers = .*:11211/)

--- a/test/integration/block_storage_controller/serverspec/block_storage_controller_spec.rb
+++ b/test/integration/block_storage_controller/serverspec/block_storage_controller_spec.rb
@@ -19,11 +19,11 @@ end
 describe file('/etc/cinder/cinder.conf') do
   its(:content) do
     should contain(/^volume_clear_size = 256$/)
-      .from(/^\[DEFAULT\]$/).to(/^\[/)
+      .from(/^\[lvm\]$/).to(/^\[/)
   end
   its(:content) do
     should contain(/^volume_group = openstack$/)
-      .from(/^\[DEFAULT\]$/).to(/^\[/)
+      .from(/^\[lvm\]$/).to(/^\[/)
   end
   its(:content) do
     should contain(/memcached_servers = .*:11211/)

--- a/test/integration/chef-provisioning/compute.rb
+++ b/test/integration/chef-provisioning/compute.rb
@@ -38,11 +38,9 @@ config.vm.provider "virtualbox" do |v|
   v.memory = 1024
 end
 EOF
+  recipe 'openstack_test::ceph_compute'
   role provision_role
   role 'separate_network_node' if ENV['SEPARATE_NETWORK_NODE']
-  attribute %w(osl-openstack credentials image_token), ENV['IMAGE_TOKEN']
-  attribute %w(osl-openstack credentials block_token), ENV['BLOCK_TOKEN']
-  attribute %w(osl-openstack credentials block_backup_token), ENV['BLOCK_BACKUP_TOKEN']
   recipe 'osl-openstack::compute'
   role 'openstack_cinder'
   file('/etc/chef/encrypted_data_bag_secret',

--- a/test/integration/chef-provisioning/compute.rb
+++ b/test/integration/chef-provisioning/compute.rb
@@ -40,6 +40,9 @@ end
 EOF
   role provision_role
   role 'separate_network_node' if ENV['SEPARATE_NETWORK_NODE']
+  attribute %w(osl-openstack credentials image_token), ENV['IMAGE_TOKEN']
+  attribute %w(osl-openstack credentials block_token), ENV['BLOCK_TOKEN']
+  attribute %w(osl-openstack credentials block_backup_token), ENV['BLOCK_BACKUP_TOKEN']
   recipe 'osl-openstack::compute'
   role 'openstack_cinder'
   file('/etc/chef/encrypted_data_bag_secret',

--- a/test/integration/chef-provisioning/controller.rb
+++ b/test/integration/chef-provisioning/controller.rb
@@ -41,6 +41,9 @@ end
 EOF
   role provision_role
   role 'separate_network_node' if ENV['SEPARATE_NETWORK_NODE']
+  attribute %w(osl-openstack credentials image_token), ENV['IMAGE_TOKEN']
+  attribute %w(osl-openstack credentials block_token), ENV['BLOCK_TOKEN']
+  attribute %w(osl-openstack credentials block_backup_token), ENV['BLOCK_BACKUP_TOKEN']
   recipe 'osl-openstack::ops_database'
   recipe 'openstack_test::gluster'
   recipe 'osl-openstack::controller'

--- a/test/integration/chef-provisioning/controller.rb
+++ b/test/integration/chef-provisioning/controller.rb
@@ -39,11 +39,10 @@ config.vm.provider "virtualbox" do |v|
   v.cpus = 2
 end
 EOF
+  recipe 'openstack_test::ceph_setup'
   role provision_role
   role 'separate_network_node' if ENV['SEPARATE_NETWORK_NODE']
-  attribute %w(osl-openstack credentials image_token), ENV['IMAGE_TOKEN']
-  attribute %w(osl-openstack credentials block_token), ENV['BLOCK_TOKEN']
-  attribute %w(osl-openstack credentials block_backup_token), ENV['BLOCK_BACKUP_TOKEN']
+  recipe 'openstack_test::ceph'
   recipe 'osl-openstack::ops_database'
   recipe 'openstack_test::gluster'
   recipe 'osl-openstack::controller'

--- a/test/integration/compute/serverspec/compute_spec.rb
+++ b/test/integration/compute/serverspec/compute_spec.rb
@@ -17,6 +17,45 @@ describe kernel_module('tun') do
   it { should be_loaded }
 end
 
+%w(/var/run/ceph/guests /var/log/ceph).each do |d|
+  describe file(d) do
+    it { should be_owned_by 'qemu' }
+    it { should be_grouped_into 'libvirt' }
+    it { should be_directory }
+  end
+end
+
+describe user('nova') do
+  it { should belong_to_group 'ceph' }
+end
+
+describe user('cinder') do
+  it { should belong_to_group 'ceph' }
+end
+
+%w(cinder cinder-backup).each do |key|
+  describe file("/etc/ceph/ceph.client.#{key}.keyring") do
+    it { should be_owned_by 'ceph' }
+    it { should be_grouped_into 'ceph' }
+    its(:content) { should match(%r{key = [A-Za-z0-9+/].*==$}) }
+  end
+end
+
+describe command('virsh secret-list') do
+  its(:stdout) do
+    should match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\s.+\
+ceph client.cinder secret/)
+  end
+end
+
+describe command('virsh secret-list | grep client.cinder | awk \'{print $1}\' | xargs -n 1 virsh secret-get-value') do
+  its(:stdout) { should match(%r{^[A-Za-z0-9+/].*==$}) }
+end
+
+describe file('/tmp/kitchen/cache/secret.xml') do
+  it { should_not exist }
+end
+
 describe file('/etc/sysconfig/libvirt-guests') do
   its(:content) { should match(/^ON_BOOT=ignore$/) }
   its(:content) { should match(/^ON_SHUTDOWN=shutdown$/) }

--- a/test/integration/compute/serverspec/compute_spec.rb
+++ b/test/integration/compute/serverspec/compute_spec.rb
@@ -25,12 +25,10 @@ end
   end
 end
 
-describe user('nova') do
-  it { should belong_to_group 'ceph' }
-end
-
-describe user('cinder') do
-  it { should belong_to_group 'ceph' }
+%w(nova cinder qemu).each do |u|
+  describe user(u) do
+    it { should belong_to_group 'ceph' }
+  end
 end
 
 %w(cinder cinder-backup).each do |key|

--- a/test/integration/dashboard/serverspec/dashboard_spec.rb
+++ b/test/integration/dashboard/serverspec/dashboard_spec.rb
@@ -17,7 +17,7 @@ MemcachedCache',/)
     should contain(/'LOCATION': \[\n\s*'.*:11211',/)
   end
   its(:content) do
-    should match(/
+    should_not match(/
 LAUNCH_INSTANCE_DEFAULTS = {
   'create_volume': 'false',
   'disable_volume': 'true',

--- a/test/integration/default/data_bags/ceph/openstack.json
+++ b/test/integration/default/data_bags/ceph/openstack.json
@@ -1,0 +1,10 @@
+{
+  "id": "openstack",
+  "ceph": {
+    "encrypted_data": "mxrjuedPidGxweiRWfvkc6nJBphv27pDbqjTCi1iYHS1aCxuJNpa5G+GHQxe\n2N0Bx0UAf1a2txuZpe+jhKiLwRYCD8F+7rpRG0sAMO5z6am1/qS2UvSqTfwL\nMYYStN18Hv+zOGqqLmNKfdMgeOIFXGMEX7jm5iWO/LIewdJGgWkLgvG4Ou7D\neenfnSTLbpsmBSJbqaqo24N0qexukwfTaFjFPEXjQe8iPyKtpHa0wkXvsBv5\nr83iY8jtWAx0GQYuv60EoovAMesdhBIe36vA7A==\n",
+    "hmac": "5ThRZsLqSl+siFE2pyUM46SYeGL/usm4fza3wbkEahY=\n",
+    "iv": "mOEgwcWRJVEBJIybOy1QeA==\n",
+    "version": 2,
+    "cipher": "aes-256-cbc"
+  }
+}

--- a/test/integration/image/serverspec/image_spec.rb
+++ b/test/integration/image/serverspec/image_spec.rb
@@ -39,6 +39,7 @@ end
 
 describe command('source /root/openrc && /usr/local/bin/openstack image show cirros -c properties -f value') do
   its(:stdout) { should match(/direct_url='rbd:/) }
+  its(:stdout) { should match(/locations=/) }
 end
 
 describe command('rbd ls images') do

--- a/test/integration/image/serverspec/image_spec.rb
+++ b/test/integration/image/serverspec/image_spec.rb
@@ -37,6 +37,24 @@ describe command('source /root/openrc && /usr/local/bin/openstack image list') d
   end
 end
 
+describe command('source /root/openrc && /usr/local/bin/openstack image show cirros -c properties -f value') do
+  its(:stdout) { should match(/direct_url='rbd:/) }
+end
+
+describe command('rbd ls images') do
+  its(:stdout) { should match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/) }
+end
+
+describe user('glance') do
+  it { should belong_to_group 'ceph' }
+end
+
+describe file('/etc/ceph/ceph.client.glance.keyring') do
+  its(:content) { should match(%r{key = [A-Za-z0-9+/].*==$}) }
+  it { should be_owned_by 'ceph' }
+  it { should be_grouped_into 'ceph' }
+end
+
 describe file('/var/lib/glance/images') do
   it { should be_mounted.with(type: 'fuse.glusterfs') }
 end

--- a/test/integration/roles/ceph_mgr.json
+++ b/test/integration/roles/ceph_mgr.json
@@ -1,0 +1,12 @@
+{
+  "env_run_lists": {},
+  "run_list": [
+    "recipe[osl-ceph::mgr]"
+  ],
+  "chef_type": "role",
+  "override_attributes": {},
+  "default_attributes": {},
+  "json_class": "Chef::Role",
+  "description": "Ceph MGR Role",
+  "name": "ceph_mgr"
+}

--- a/test/integration/roles/ceph_mon.json
+++ b/test/integration/roles/ceph_mon.json
@@ -1,0 +1,18 @@
+{
+  "env_run_lists": {},
+  "run_list": [
+    "recipe[osl-ceph::mon]"
+  ],
+  "chef_type": "role",
+  "override_attributes": {},
+  "default_attributes": {
+    "ceph": {
+      "mon": {
+        "role": "ceph_mon"
+      }
+		}
+  },
+  "json_class": "Chef::Role",
+  "description": "Ceph Mon Role",
+  "name": "ceph_mon"
+}

--- a/test/integration/roles/openstack_provisioning.json
+++ b/test/integration/roles/openstack_provisioning.json
@@ -7,6 +7,26 @@
   ],
   "chef_type": "role",
   "override_attributes": {
+    "ceph": {
+      "mon": {
+        "role": "ceph_mon"
+      },
+      "osd": {
+        "role": "ceph_osd"
+			},
+      "network": {
+        "public": {
+          "cidr": [
+            "10.1.100.0/23"
+          ]
+        },
+        "cluster": {
+          "cidr": [
+            "10.1.100.0/23"
+          ]
+        }
+      }
+    },
     "openstack": {
       "mq": {
         "user": "admin"
@@ -41,6 +61,8 @@
     "osl-openstack": {
       "database_suffix": "x86",
       "databag_prefix": "x86",
+      "ceph": true,
+      "ceph_item": "x86_openstack",
       "endpoint_hostname": "controller.example.com",
       "db_hostname": "controller.example.com",
       "nova_public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYOuLkP1F/Sm/dCJAA7kme+ObO4J8x2HrZU40W8QqW4yFqRPKnW5HYLeUpRzIFzWen/LIn6R6lxTfSAnnD8qEEuKbFjH5WRqJYCJeAyaTBTRyU1FHlcTR/EQ/HVZ38TQwCztZgboFb5zmWqYc3/BYBHGA6XeYN5jRcHvZbyaGL+YA1/KPIjpbQfqIPXdHfodoSNX4qQQccYBq2c/rq3Puh7Q9oVph6a2lq0wWsqYyq0vTGHPKFYShVpwDl2Z3c8eB3P7yFRzOR2VNuezJlOgoHz6D/mBObLj1n+yi07bcGbpwAH/rLEyiy4gVdru2qQAcbDL9Yibk96lovim/IH4dV nova-migration",

--- a/test/integration/roles/openstack_provisioning.json
+++ b/test/integration/roles/openstack_provisioning.json
@@ -8,12 +8,6 @@
   "chef_type": "role",
   "override_attributes": {
     "ceph": {
-      "mon": {
-        "role": "ceph_mon"
-      },
-      "osd": {
-        "role": "ceph_osd"
-			},
       "network": {
         "public": {
           "cidr": [
@@ -62,7 +56,6 @@
       "database_suffix": "x86",
       "databag_prefix": "x86",
       "ceph": true,
-      "ceph_item": "x86_openstack",
       "endpoint_hostname": "controller.example.com",
       "db_hostname": "controller.example.com",
       "nova_public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYOuLkP1F/Sm/dCJAA7kme+ObO4J8x2HrZU40W8QqW4yFqRPKnW5HYLeUpRzIFzWen/LIn6R6lxTfSAnnD8qEEuKbFjH5WRqJYCJeAyaTBTRyU1FHlcTR/EQ/HVZ38TQwCztZgboFb5zmWqYc3/BYBHGA6XeYN5jRcHvZbyaGL+YA1/KPIjpbQfqIPXdHfodoSNX4qQQccYBq2c/rq3Puh7Q9oVph6a2lq0wWsqYyq0vTGHPKFYShVpwDl2Z3c8eB3P7yFRzOR2VNuezJlOgoHz6D/mBObLj1n+yi07bcGbpwAH/rLEyiy4gVdru2qQAcbDL9Yibk96lovim/IH4dV nova-migration",

--- a/test/integration/roles/openstack_tk.json
+++ b/test/integration/roles/openstack_tk.json
@@ -3,7 +3,9 @@
   "run_list": [
     "recipe[openstack_test::hosts]",
     "recipe[openstack_test::cacert]",
-    "recipe[osl-openstack]"
+    "recipe[openstack_test::ceph_setup]",
+    "recipe[osl-openstack]",
+    "recipe[openstack_test::ceph]"
   ],
   "chef_type": "role",
   "override_attributes": {

--- a/test/integration/roles/vagrant_provisioning.json
+++ b/test/integration/roles/vagrant_provisioning.json
@@ -7,6 +7,20 @@
   ],
   "chef_type": "role",
   "override_attributes": {
+    "ceph": {
+      "network": {
+        "public": {
+          "cidr": [
+            "192.168.60.0/24"
+          ]
+        },
+        "cluster": {
+          "cidr": [
+            "192.168.60.0/24"
+          ]
+        }
+      }
+    },
     "openstack": {
       "mq": {
         "user": "admin"
@@ -46,6 +60,7 @@
     "osl-openstack": {
       "database_suffix": "x86",
       "databag_prefix": "x86",
+      "ceph": true,
       "endpoint_hostname": "controller.example.com",
       "db_hostname": "controller.example.com",
       "network_hostname": "192.168.60.13",


### PR DESCRIPTION
This provides integration with Ceph which is disable by default (currently). For
the test-kitchen environment, we deploy a containerized ceph server that we can
interact with. This cookbook has a few assumptions:

- We manually create the cephx auth tokens on the Ceph server in production and
  add them to encrypted databags
- This uses a fork of the cookbook-openstack-compute repo which removes the
  'ceph' cookbook from the metadata.rb. Is this due to the upstream cookbook
  using this cookbook instead of 'ceph-chef' and produces some conflicting
  problems with attributes since they share the same name space. I'm going to be
  working with upstream to resolve this eventually.
- All VMs switch to cinder backed disks whether they are ephemeral or not
- Various OpenStack users are added to the ceph group so they can access
  configuration under /etc/ceph which is protected with permissions
- This utilizes a variety of best practice recommendations [1][2] to determine
  the settings that should be changed when enabling Ceph
- This enables live migration capability for VMs
- This removes the LAUNCH_INSTANCE_DEFAULTS settings we had before since they
  now work and are somewhat required now using Ceph
- This utilizes four different Ceph pools: vms, volumes, images and backups
  which are configurable per OpenStack cluster
- The cinder-backup service is not enabled (yet) and will be fixed in a separate
  PR

When testing the changes in this cookbook, some of the ServerSpec tests will
fail after a successful converge. It is recommended to run converge again and
try verifying the suite again. This is due to some compile time / converge time
issues with attribute precedence related to the dockerized ceph environment.
This DOES NOT impact production since we use encrypted data bags.

Here is a TODO list of things that still need to be resolved in this PR:

- [x] Fix the test provisioning environment
- [x] Test switching from non-ceph to ceph environments live

[1] http://docs.ceph.com/docs/master/rbd/rbd-openstack/
[2] https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html-single/ceph_block_device_to_openstack_guide/