### PR TITLE
Install 4.14 kernel and set kvm_cma_resv_ratio=10 on ppc64le

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -15,6 +15,7 @@ cookbook 'osl-rsync', git: 'git@github.com:osuosl-cookbooks/osl-rsync'
 cookbook 'resource_from_hash',
          git: 'git@github.com:osuosl-cookbooks/resource_from_hash'
 cookbook 'statsd', github: 'att-cloud/cookbook-statsd'
+cookbook 'yum-kernel-osuosl', git: 'git@github.com:osuosl-cookbooks/yum-kernel-osuosl.git'
 cookbook 'yum-qemu-ev', git: 'git@github.com:osuosl-cookbooks/yum-qemu-ev.git'
 cookbook 'ibm-power', git: 'git@github.com:osuosl-cookbooks/ibm-power.git'
 cookbook 'openstackclient', github: 'cloudbau/cookbook-openstackclient'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,12 +8,12 @@ description      'Installs/Configures osl-openstack'
 long_description 'Installs/Configures osl-openstack'
 version          '3.1.6'
 
-%w{ base certificate chef-sugar git memcached osl-nrpe kernel-modules
+%w{ base certificate chef-sugar git memcached osl-nrpe osl-munin kernel-modules
   mysql openstack-block-storage openstack-common openstack-compute
   openstack-dashboard openstack-identity openstack-integration-test
   openstack-image openstack-network openstack-ops-database
   openstack-ops-messaging openstack-orchestration openstack-telemetry selinux
-  sudo yum-qemu-ev ibm-power apache2 yum-epel}.each do |cb|
+  sudo yum-qemu-ev ibm-power apache2 yum-epel yum-kernel-osuosl}.each do |cb|
   depends cb
 end
 

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -26,7 +26,13 @@ kernel_module 'tun'
 
 case node['kernel']['machine']
 when 'ppc64le'
+  node.default['base']['grub']['cmdline'] << %w(kvm_cma_resv_ratio=10)
   include_recipe 'chef-sugar::default'
+  include_recipe 'yum-kernel-osuosl'
+  include_recipe 'base::grub'
+
+  package 'kernel-osuosl'
+
   if %w(openstack).include?(node.deep_fetch('cloud', 'provider'))
     kernel_module 'kvm_pr'
   else

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -113,8 +113,16 @@ Host *
     it 'loads kvm_hv module' do
       expect(chef_run).to load_kernel_module('kvm_hv')
     end
-    it 'includes cookbook chef-sugar::default' do
-      expect(chef_run).to include_recipe('chef-sugar::default')
+    %w(chef-sugar::default yum-kernel-osuosl base::grub).each do |r|
+      it do
+        expect(chef_run).to include_recipe(r)
+      end
+    end
+    it do
+      expect(chef_run).to install_package('kernel-osuosl')
+    end
+    it do
+      expect(chef_run).to render_file('/etc/default/grub').with_content(/^GRUB_CMDLINE_LINUX=.*kvm_cma_resv_ratio=10/)
     end
     it 'creates /etc/rc.d/rc.local' do
       expect(chef_run).to create_cookbook_file('/etc/rc.d/rc.local')


### PR DESCRIPTION
On ppc64le, we need to run a newer mainline kernel so that we get the best
support for the hardware. In addition, to deal with vms not booting due to CMA
(See [1] for detail on what CMA is) memory issues, let's increase the ratio from
the default of 5 to 10. This number is a percentage of memory for hash pagetable
allocation. I've been running with 10% on openpower2 for several months and it
seems to have stopped the issue.

In addition, add a new munin graph which tracks the CMA memory usage on hosts
which have that information available in /proc.

[1] https://lwn.net/Articles/486301/