### PR TITLE
Account for case sensitivity when loading KVM in x86 cluster

### DIFF
--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -67,14 +67,14 @@ when 'x86_64'
     reload false
     options %w(nested=1)
     check_availability true
-    only_if { node.deep_fetch('dmi', 'processor', 'manufacturer') == 'Intel(R) Corporation' }
+    only_if { node.deep_fetch('dmi', 'processor', 'Manufacturer') == 'Intel(R) Corporation' }
   end
   kernel_module 'kvm_amd' do
     onboot true
     reload false
     options %w(nested=1)
     check_availability true
-    only_if { node.deep_fetch('dmi', 'processor', 'manufacturer') == 'AMD' }
+    only_if { node.deep_fetch('dmi', 'processor', 'Manufacturer') == 'AMD' }
   end
 end
 

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -273,7 +273,7 @@ Host *
     cached(:chef_run) { runner.converge(described_recipe) }
     before do
       node.automatic['kernel']['machine'] = 'x86_64'
-      node.automatic['dmi']['processor']['manufacturer'] = 'Intel(R) Corporation'
+      node.automatic['dmi']['processor']['Manufacturer'] = 'Intel(R) Corporation'
     end
     it 'loads kvm_intel module with nested option' do
       expect(chef_run).to load_kernel_module('kvm_intel').with(
@@ -291,7 +291,7 @@ Host *
     cached(:chef_run) { runner.converge(described_recipe) }
     before do
       node.automatic['kernel']['machine'] = 'x86_64'
-      node.automatic['dmi']['processor']['manufacturer'] = 'AMD'
+      node.automatic['dmi']['processor']['Manufacturer'] = 'AMD'
     end
     it 'loads kvm_amd module with nested option' do
       expect(chef_run).to load_kernel_module('kvm_amd').with(


### PR DESCRIPTION
The attributes are case sensitive. This will fix the processor attribute so
it checks for the attribute that exists.