### PR TITLE
Fix duplicated resources for group[ceph]

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -165,6 +165,7 @@ suites:
       - recipe[openstack-block-storage::volume_driver_lvm]
       - recipe[osl-openstack::block_storage]
       - recipe[openstack-integration-test::setup]
+      - recipe[openstack_test::tempest]
       - recipe[openstack_test::orchestration]
     attributes:
       osl-openstack:

--- a/recipes/_block_ceph.rb
+++ b/recipes/_block_ceph.rb
@@ -2,7 +2,8 @@ secrets = openstack_credential_secrets
 
 package 'openstack-cinder'
 
-group 'ceph' do
+group 'ceph-block' do
+  group_name 'ceph'
   append true
   members %w(cinder)
   action :modify

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -93,7 +93,8 @@ if node['osl-openstack']['ceph']
 
   include_recipe 'osl-openstack::_block_ceph'
 
-  group 'ceph' do
+  group 'ceph-compute' do
+    group_name 'ceph'
     append true
     members %w(nova qemu)
     action :modify

--- a/recipes/image.rb
+++ b/recipes/image.rb
@@ -25,7 +25,8 @@ include_recipe 'openstack-image::identity_registration'
 if node['osl-openstack']['ceph']
   secrets = openstack_credential_secrets
 
-  group 'ceph' do
+  group 'ceph-image' do
+    group_name 'ceph'
     append true
     members %w(glance)
     action :modify

--- a/spec/block_storage_spec.rb
+++ b/spec/block_storage_spec.rb
@@ -61,14 +61,15 @@ describe 'osl-openstack::block_storage' do
       expect(chef_run).to install_package('openstack-cinder')
     end
     it do
-      expect(chef_run).to modify_group('ceph')
+      expect(chef_run).to modify_group('ceph-block')
         .with(
+          group_name: 'ceph',
           append: true,
           members: %w(cinder)
         )
     end
     it do
-      expect(chef_run.group('ceph')).to notify('service[cinder-volume]').to(:restart).immediately
+      expect(chef_run.group('ceph-block')).to notify('service[cinder-volume]').to(:restart).immediately
     end
     it do
       expect(chef_run.template('/etc/ceph/ceph.client.cinder.keyring')).to notify('service[cinder-volume]')

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -128,17 +128,18 @@ Host *
       expect(chef_run).to include_recipe('osl-openstack::_block_ceph')
     end
     it do
-      expect(chef_run).to modify_group('ceph')
+      expect(chef_run).to modify_group('ceph-compute')
         .with(
+          group_name: 'ceph',
           append: true,
           members: %w(nova qemu)
         )
     end
     it do
-      expect(chef_run.group('ceph')).to notify('service[nova-compute]').to(:restart).immediately
+      expect(chef_run.group('ceph-compute')).to notify('service[nova-compute]').to(:restart).immediately
     end
     it do
-      expect(chef_run.group('ceph')).to_not notify('service[cinder-volume]').to(:restart).immediately
+      expect(chef_run.group('ceph-compute')).to_not notify('service[cinder-volume]').to(:restart).immediately
     end
     it do
       expect(chef_run.template('/etc/ceph/ceph.client.cinder.keyring')).to_not notify('service[cinder-volume]')

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -49,14 +49,15 @@ describe 'osl-openstack::image', image: true do
         include_context 'common_stubs'
         include_context 'ceph_stubs'
         it do
-          expect(chef_run).to modify_group('ceph')
+          expect(chef_run).to modify_group('ceph-image')
             .with(
+              group_name: 'ceph',
               append: true,
               members: %w(glance)
             )
         end
         it do
-          expect(chef_run.group('ceph')).to notify('service[glance-api]').to(:restart).immediately
+          expect(chef_run.group('ceph-image')).to notify('service[glance-api]').to(:restart).immediately
         end
         it do
           expect(chef_run).to create_template('/etc/ceph/ceph.client.glance.keyring')

--- a/test/cookbooks/openstack_test/recipes/tempest.rb
+++ b/test/cookbooks/openstack_test/recipes/tempest.rb
@@ -1,0 +1,3 @@
+edit_resource(:python_virtualenv, '/opt/tempest-venv') do
+  pip_version '9.0.3'
+end


### PR DESCRIPTION
This fixes running the all-in-one (aio) suite and also resolves some other
issues where we had the same resource set in three different recipes. Even
though we're editing the same group, the resource NAME needs to be different.

In addition, we need to ensure the tempest virtualenv isn't using pip 10.0.0
which breaks it otherwise.

This should also provide some fixes for the packer builds.