### PR TITLE
Install older version of cliff python package

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -410,13 +410,32 @@ include_recipe 'openstack-common::logging'
 include_recipe 'openstack-common::sysctl'
 include_recipe 'openstack-identity::openrc'
 include_recipe 'build-essential'
-include_recipe 'openstack-common::client'
-include_recipe 'osl-ceph' if node['osl-openstack']['ceph']
 
-edit_resource(:python_runtime, '2') do
+# TODO: Replace this with openstack-common::client when switching to Pike
+python_runtime '2' do
   provider :system
   pip_version '9.0.3'
 end
+
+python_virtualenv '/opt/osc' do
+  system_site_packages true
+end
+
+python_package 'cliff' do
+  version '2.9.0'
+  virtualenv '/opt/osc'
+end
+
+python_package 'python-openstackclient' do
+  version node['openstack']['common']['client_version']
+  virtualenv '/opt/osc'
+end
+
+link '/usr/local/bin/openstack' do
+  to '/opt/osc/bin/openstack'
+end
+
+include_recipe 'osl-ceph' if node['osl-openstack']['ceph']
 
 # Needed for accessing neutron when running separate from controller node
 package 'python-memcached'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -49,11 +49,37 @@ describe 'osl-openstack::default' do
     openstack-common::logging
     openstack-common::sysctl
     openstack-identity::openrc
-    openstack-common::client
   ).each do |r|
     it do
       expect(chef_run).to include_recipe(r)
     end
+  end
+  it do
+    expect(chef_run).to install_python_runtime('2')
+      .with(
+        provider: PoisePython::PythonProviders::System,
+        pip_version: '9.0.3'
+      )
+  end
+  it do
+    expect(chef_run).to create_python_virtualenv('/opt/osc').with(system_site_packages: true)
+  end
+  it do
+    expect(chef_run).to install_python_package('cliff')
+      .with(
+        version: '2.9.0',
+        # virtualenv: '/opt/osc'
+      )
+  end
+  it do
+    expect(chef_run).to install_python_package('python-openstackclient')
+      .with(
+        version: '3.11.0',
+        # virtualenv: '/opt/osc'
+      )
+  end
+  it do
+    expect(chef_run.link('/usr/local/bin/openstack')).to link_to('/opt/osc/bin/openstack')
   end
   it do
     expect(chef_run).to install_package('python-memcached')

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -33,3 +33,7 @@ describe file('/etc/sysconfig/iptables-config') do
   its(:content) { should match(/^IPTABLES_SAVE_ON_STOP="no"$/) }
   its(:content) { should match(/^IPTABLES_SAVE_ON_RESTART="no"$/) }
 end
+
+describe command('/usr/local/bin/openstack -h') do
+  its(:exit_status) { should eq 0 }
+end


### PR DESCRIPTION
This resolves an issue that the current latest version has with our environment.
Unfortunately it wasn't easy to override what the upstream cookbooks were doing
so I went ahead and just replicated the code it uses and just added the one-off
case here.

Looks like this can be removed when we switch to Pike as the upstream cookbooks
move back to yum packages.