### PR TITLE
Uninstall newer version of fog-openstack which breaks upstream openstack cb

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -21,7 +21,9 @@ cookbook 'statsd', github: 'att-cloud/cookbook-statsd'
 cookbook 'yum-kernel-osuosl', git: 'git@github.com:osuosl-cookbooks/yum-kernel-osuosl.git'
 cookbook 'yum-qemu-ev', git: 'git@github.com:osuosl-cookbooks/yum-qemu-ev.git'
 cookbook 'ibm-power', git: 'git@github.com:osuosl-cookbooks/ibm-power.git'
-cookbook 'openstackclient', github: 'cloudbau/cookbook-openstackclient'
+cookbook 'openstackclient',
+         git: 'git@github.com:osuosl-cookbooks/cookbook-openstackclient',
+         branch: 'lock-fog-openstack'
 
 # WIP patches
 %w(

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -410,6 +410,11 @@ include_recipe 'openstack-common::sysctl'
 include_recipe 'openstack-identity::openrc'
 include_recipe 'build-essential'
 
+execute 'uninstall >= fog-openstack-0.2.0' do
+  command "/opt/chef/embedded/bin/gem uninstall -v '>= 0.2.0' fog-openstack --no-user-install"
+  only_if "/opt/chef/embedded/bin/gem list -i -v '>= 0.2.0' fog-openstack"
+end
+
 # TODO: Replace this with openstack-common::client when switching to Pike
 python_runtime '2' do
   provider :system

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -54,6 +54,24 @@ describe 'osl-openstack::default' do
     end
   end
   it do
+    expect(chef_run).to_not run_execute('uninstall >= fog-openstack-0.2.0')
+      .with(command: "/opt/chef/embedded/bin/gem uninstall -v '>= 0.2.0' fog-openstack --no-user-install")
+  end
+  context 'newer fog-openstack installed' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
+        node.automatic['filesystem2']['by_mountpoint']
+      end.converge(described_recipe)
+    end
+    before do
+      stub_command("/opt/chef/embedded/bin/gem list -i -v '>= 0.2.0' fog-openstack").and_return(true)
+    end
+    it do
+      expect(chef_run).to run_execute('uninstall >= fog-openstack-0.2.0')
+        .with(command: "/opt/chef/embedded/bin/gem uninstall -v '>= 0.2.0' fog-openstack --no-user-install")
+    end
+  end
+  it do
     expect(chef_run).to install_python_runtime('2')
       .with(
         provider: PoisePython::PythonProviders::System,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -134,6 +134,7 @@ shared_context 'identity_stubs' do
     allow_any_instance_of(Chef::Recipe).to receive(:rabbit_transport_url)
       .with('identity')
       .and_return('rabbit://openstack:openstack@controller.example.org:5672')
+    stub_command("/opt/chef/embedded/bin/gem list -i -v '>= 0.2.0' fog-openstack")
   end
 end
 

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -37,3 +37,7 @@ end
 describe command('/usr/local/bin/openstack -h') do
   its(:exit_status) { should eq 0 }
 end
+
+describe command("/opt/chef/embedded/bin/gem list -i -v '>= 0.2.0' fog-openstack") do
+  its(:stdout) { should match(/^false$/) }
+end

--- a/test/integration/identity/serverspec/identity_spec.rb
+++ b/test/integration/identity/serverspec/identity_spec.rb
@@ -31,3 +31,11 @@ end
 describe file('/etc/httpd/sites-enabled/keystone-main.conf') do
   its(:content) { should contain(/<VirtualHost 0.0.0.0:5000>/) }
 end
+
+describe command("/opt/chef/embedded/bin/gem list -i -v '>= 0.2.0' fog-openstack") do
+  its(:stdout) { should match(/^false$/) }
+end
+
+describe command("/opt/chef/embedded/bin/gem list -i -v '< 0.2.0' fog-openstack") do
+  its(:stdout) { should match(/^true$/) }
+end


### PR DESCRIPTION
This is a temporarily solution to get chef runs going again and points to a fork
of the openstackclient cookbook which ensures we don't install the newer
version. I'm working with upstream to get this properly fixed.

NOTE: I added the ServerSpec also in the identity suite since this doesn't get
pulled until the openstackclient gets pulled in from recipes such as identity.