### PR TITLE
Fix deprecation warnings in Newton

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -92,6 +92,7 @@ suites:
     driver_config:
         server_name: "network-<%= ENV['USER'] %>"
     run_list:
+      - recipe[openstack_test]
       - role[openstack_tk]
       - role[openstack_ops_identity]
       - recipe[osl-openstack::network]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -223,6 +223,8 @@ node.default['openstack']['block-storage']['conf'].tap do |conf|
   conf['oslo_messaging_notifications']['driver'] = 'messagingv2'
   conf['DEFAULT']['volume_group'] = 'openstack'
   conf['DEFAULT']['volume_clear_size'] = 256
+  conf['DEFAULT']['enable_v1_api'] = false
+  conf['DEFAULT']['enable_v3_api'] = true
   if node['osl-openstack']['ceph']
     conf['DEFAULT']['enabled_backends'] = 'ceph'
     conf['DEFAULT']['backup_driver'] = 'cinder.backup.drivers.ceph'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -175,7 +175,7 @@ end
 node.default['openstack']['network_l3']['conf'].tap do |conf|
   conf['DEFAULT']['interface_driver'] =
     'neutron.agent.linux.interface.BridgeInterfaceDriver'
-  conf['DEFAULT']['external_network_bridge'] = nil
+  conf['DEFAULT'].delete('external_network_bridge')
 end
 node.default['openstack']['network_dhcp']['conf'].tap do |conf|
   conf['DEFAULT']['interface_driver'] =

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -297,9 +297,6 @@ end
     conf['cache']['enabled'] = true
     conf['cache']['backend'] = 'oslo_cache.memcache_pool'
     conf['keystone_authtoken']['memcached_servers'] = memcached_servers
-    conf['oslo_messaging_rabbit']['rabbit_host'] = endpoint_hostname
-    conf['oslo_messaging_rabbit']['rabbit_userid'] = rabbit_user
-    conf['oslo_messaging_rabbit']['rabbit_password'] = rabbit_pass
   end
   node.override['openstack'][i]['conf_secrets']['DEFAULT'].tap do |conf|
     conf['transport_url'] = "rabbit://#{rabbit_user}:#{rabbit_pass}@#{endpoint_hostname}:#{rabbit_port}"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -107,7 +107,8 @@ node.default['openstack']['identity']['pipeline']['api_v3'] =
     service_v3
   ).join(' ')
 node.default['openstack']['image_api']['conf'].tap do |conf|
-  conf['DEFAULT']['enable_v1_api'] = false
+  # enable_v1_api needs to be enabled for heat in Newton
+  # conf['DEFAULT']['enable_v1_api'] = false
   conf['DEFAULT']['enable_v2_api'] = true
   if node['osl-openstack']['ceph']
     conf['DEFAULT']['show_image_direct_url'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -207,6 +207,10 @@ node.default['openstack']['network']['plugins']['linuxbridge']['conf']
   conf['securitygroup']['firewall_driver'] =
     'neutron.agent.linux.iptables_firewall.IptablesFirewallDriver'
 end
+node.default['openstack']['orchestration']['conf'].tap do |conf|
+  conf['trustee'].delete('auth_plugin')
+  conf['trustee']['auth_type'] = 'v3password'
+end
 node.default['openstack']['dashboard'].tap do |conf|
   conf['ssl']['use_data_bag'] = false
   conf['ssl']['key'] = 'wildcard.key'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -107,8 +107,14 @@ node.default['openstack']['identity']['pipeline']['api_v3'] =
     service_v3
   ).join(' ')
 node.default['openstack']['image_api']['conf'].tap do |conf|
+  conf['DEFAULT']['enable_v1_api'] = false
+  conf['DEFAULT']['enable_v2_api'] = true
   if node['osl-openstack']['ceph']
     conf['DEFAULT']['show_image_direct_url'] = true
+    # show_multiple_locations will be deprecated soon [1][2][3]
+    # [1] https://docs.openstack.org/releasenotes/glance/newton.html#relnotes-13-0-0-origin-stable-newton
+    # [2] https://docs.openstack.org/releasenotes/glance/ocata.html#relnotes-14-0-0-origin-stable-ocata-other-notes
+    # [3] https://wiki.openstack.org/wiki/OSSN/OSSN-0065
     conf['DEFAULT']['show_multiple_locations'] = true
     conf['paste_deploy']['flavor'] = 'keystone'
     conf['glance_store']['stores'] = 'rbd,file,http'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -436,6 +436,26 @@ node.default['openstack']['endpoints'].tap do |conf|
   end
 end
 
+%w(
+  compute
+  block-storage
+  image_registry
+  image_api
+  network
+  network_dhcp
+  network_l3
+  network_metadata
+  network_metering
+  orchestration
+  telemetry
+).each do |i|
+  identity_endpoint = public_endpoint 'identity'
+  auth_url = auth_uri_transform identity_endpoint.to_s, node['openstack']['api']['auth']['version']
+  node.default['openstack'][i]['conf'].tap do |conf|
+    conf['keystone_authtoken']['auth_uri'] = auth_url
+  end
+end
+
 yum_repository 'OSL-openpower-openstack' do
   description "OSL Openpower OpenStack repo for #{node['platform']}-#{node['platform_version'].to_i}" \
               "/openstack-#{node['openstack']['release']}"

--- a/recipes/identity.rb
+++ b/recipes/identity.rb
@@ -33,6 +33,7 @@ end
 # restarted.
 %w(
   /etc/keystone/keystone.conf
+  /etc/keystone/keystone-paste.ini
   /etc/httpd/sites-available/keystone-admin.conf
   /etc/httpd/sites-available/keystone-main.conf
 ).each do |t|

--- a/spec/block_storage_controller_spec.rb
+++ b/spec/block_storage_controller_spec.rb
@@ -41,12 +41,13 @@ describe 'osl-openstack::block_storage_controller' do
           /^driver = messagingv2$/
         )
     end
-    it do
-      expect(chef_run).to render_config_file(file.name)
-        .with_section_content(
-          'keystone_authtoken',
-          %r{^auth_url = https://10.0.0.10:5000/v3$}
-        )
+    [
+      %r{^auth_url = https://10.0.0.10:5000/v3$},
+      %r{^auth_uri = https://10.0.0.10:5000/v3$},
+    ].each do |line|
+      it do
+        expect(chef_run).to render_config_file(file.name).with_section_content('keystone_authtoken', line)
+      end
     end
     it do
       expect(chef_run).to render_config_file(file.name)

--- a/spec/block_storage_controller_spec.rb
+++ b/spec/block_storage_controller_spec.rb
@@ -28,6 +28,8 @@ describe 'osl-openstack::block_storage_controller' do
       /^osapi_volume_listen = 10.0.0.2$/,
       /^volume_group = openstack$/,
       /^volume_clear_size = 256$/,
+      /^enable_v1_api = false$/,
+      /^enable_v3_api = true$/,
       %r{^transport_url = rabbit://guest:mq-pass@10.0.0.10:5672$},
     ].each do |line|
       it do

--- a/spec/block_storage_controller_spec.rb
+++ b/spec/block_storage_controller_spec.rb
@@ -71,16 +71,6 @@ describe 'osl-openstack::block_storage_controller' do
         expect(chef_run).to render_config_file(file.name).with_section_content('cache', line)
       end
     end
-
-    [
-      /^rabbit_host = 10.0.0.10$/,
-      /^rabbit_userid = guest$/,
-      /^rabbit_password = mq-pass$/,
-    ].each do |line|
-      it do
-        expect(chef_run).to render_config_file(file.name).with_section_content('oslo_messaging_rabbit', line)
-      end
-    end
     context 'Set ceph' do
       let(:runner) do
         ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|

--- a/spec/compute_controller_spec.rb
+++ b/spec/compute_controller_spec.rb
@@ -103,16 +103,6 @@ AggregateInstanceExtraSpecsFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter
     end
 
     [
-      /^rabbit_host = 10.0.0.10$/,
-      /^rabbit_userid = guest$/,
-      /^rabbit_password = mq-pass$/,
-    ].each do |line|
-      it do
-        expect(chef_run).to render_config_file(file.name).with_section_content('oslo_messaging_rabbit', line)
-      end
-    end
-
-    [
       %r{^novncproxy_base_url = https://10.0.0.10:6080/vnc_auto.html$},
       %r{^xvpvncproxy_base_url = http://10.0.0.10:6081/console$},
       /^xvpvncproxy_host = 10.0.0.2$/,

--- a/spec/compute_controller_spec.rb
+++ b/spec/compute_controller_spec.rb
@@ -67,6 +67,7 @@ AggregateInstanceExtraSpecsFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter
     [
       /^memcached_servers = 10.0.0.10:11211$/,
       %r{^auth_url = https://10.0.0.10:5000/v3$},
+      %r{^auth_uri = https://10.0.0.10:5000/v3$},
     ].each do |line|
       it do
         expect(chef_run).to render_config_file(file.name).with_section_content('keystone_authtoken', line)

--- a/spec/identity_spec.rb
+++ b/spec/identity_spec.rb
@@ -51,17 +51,6 @@ describe 'osl-openstack::identity', identity: true do
           .with_section_content('cache', line)
       end
     end
-    [
-      /^rabbit_host = 10.0.0.10$/,
-      /^rabbit_userid = guest$/,
-      /^rabbit_password = guest$/,
-    ].each do |line|
-      it do
-        expect(chef_run).to render_config_file(file.name)
-          .with_section_content('oslo_messaging_rabbit', line)
-      end
-    end
-
     it do
       expect(chef_run).to render_config_file(file.name)
         .with_section_content(

--- a/spec/identity_spec.rb
+++ b/spec/identity_spec.rb
@@ -22,6 +22,7 @@ describe 'osl-openstack::identity', identity: true do
   end
   %w(
     /etc/keystone/keystone.conf
+    /etc/keystone/keystone-paste.ini
     /etc/httpd/sites-available/keystone-admin.conf
     /etc/httpd/sites-available/keystone-main.conf
   ).each do |t|
@@ -58,6 +59,52 @@ describe 'osl-openstack::identity', identity: true do
           %r{^connection = mysql://keystone_x86:keystone_db_pass@10.0.0.10:\
 3306/keystone_x86\?charset=utf8$}
         )
+    end
+    it do
+      expect(chef_run).to_not render_config_file(file.name)
+        .with_section_content('catalog', 'keystone.catalog.backends.sql.Catalog')
+    end
+    it do
+      expect(chef_run).to_not render_config_file(file.name)
+        .with_section_content('policy', 'driver = keystone.policy.backends.sql.Policy')
+    end
+    it do
+      expect(chef_run).to_not render_config_file(file.name)
+        .with_section_content('assignment', 'driver = keystone.assignment.backends.sql.Assignment')
+    end
+  end
+  describe '/etc/keystone/keystone-paste.ini' do
+    let(:file) do
+      chef_run.template('/etc/keystone/keystone-paste.ini')
+    end
+    [
+      /^use = egg:oslo.middleware\#cors$/,
+      /^oslo_config_project = keystone$/,
+    ].each do |line|
+      it do
+        expect(chef_run).to render_config_file(file.name)
+          .with_section_content('filter:cors', line)
+      end
+    end
+    it do
+      expect(chef_run).to_not render_config_file(file.name)
+        .with_section_content('filter:osprofiler', 'use = egg:osprofiler\#osprofiler')
+    end
+    it do
+      expect(chef_run).to_not render_config_file(file.name)
+        .with_section_content('filter:http_proxy_to_wsgi', 'use = egg:oslo.middleware\#http_proxy_to_wsgi')
+    end
+    it do
+      expect(chef_run).to render_config_file(file.name)
+        .with_section_content('pipeline:public_api', 'pipeline = cors sizelimit http_proxy_to_wsgi osprofiler url_normalize request_id build_auth_context token_auth json_body ec2_extension public_service')
+    end
+    it do
+      expect(chef_run).to render_config_file(file.name)
+        .with_section_content('pipeline:admin_api', 'pipeline = cors sizelimit http_proxy_to_wsgi osprofiler url_normalize request_id build_auth_context token_auth json_body ec2_extension s3_extension admin_service')
+    end
+    it do
+      expect(chef_run).to render_config_file(file.name)
+        .with_section_content('pipeline:api_v3', 'pipeline = cors sizelimit http_proxy_to_wsgi osprofiler url_normalize request_id build_auth_context token_auth json_body ec2_extension_v3 s3_extension service_v3')
     end
   end
   describe '/etc/httpd/sites-available/keystone-admin.conf' do

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -34,7 +34,7 @@ describe 'osl-openstack::image', image: true do
       case f
       when 'api'
         [
-          /^enable_v1_api = false$/,
+          # /^enable_v1_api = false$/,
           /^enable_v2_api = true$/,
         ].each do |line|
           it do

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -168,6 +168,7 @@ describe 'osl-openstack::image', image: true do
       [
         /^memcached_servers = 10.0.0.10:11211$/,
         %r{^auth_url = https://10.0.0.10:5000/v3$},
+        %r{^auth_uri = https://10.0.0.10:5000/v3$},
       ].each do |line|
         it do
           expect(chef_run).to render_config_file(file.name)

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -165,19 +165,7 @@ describe 'osl-openstack::image', image: true do
       end
 
       [
-        /^rabbit_host = 10.0.0.10$/,
-        /^rabbit_userid = guest$/,
-        /^rabbit_password = mq-pass$/,
-      ].each do |line|
-        it do
-          expect(chef_run).to render_config_file(file.name)
-            .with_section_content('oslo_messaging_rabbit', line)
-        end
-      end
-
-      [
-        %r{^connection = mysql://glance_x86:db-pass@10.0.0.10:3306/glance_x86\
-\?charset=utf8$},
+        %r{^connection = mysql://glance_x86:db-pass@10.0.0.10:3306/glance_x86\?charset=utf8$},
       ].each do |line|
         it do
           expect(chef_run).to render_config_file(file.name)

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -31,6 +31,17 @@ describe 'osl-openstack::image', image: true do
           expect(chef_run).to render_config_file(file.name).with_section_content('DEFAULT', line)
         end
       end
+      case f
+      when 'api'
+        [
+          /^enable_v1_api = false$/,
+          /^enable_v2_api = true$/,
+        ].each do |line|
+          it do
+            expect(chef_run).to render_config_file(file.name).with_section_content('DEFAULT', line)
+          end
+        end
+      end
       context 'Set ceph' do
         next unless f == 'api'
         let(:runner) do

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -98,6 +98,16 @@ neutron.services.l3_router.l3_router_plugin.L3RouterPlugin$/,
             %r{^auth_url = https://10.0.0.10:5000/v3$}
           )
       end
+      case s
+      when 'keystone_authtoken'
+        it do
+          expect(chef_run).to render_config_file(file.name)
+            .with_section_content(
+              s,
+              %r{^auth_uri = https://10.0.0.10:5000/v3$}
+            )
+        end
+      end
     end
     it do
       expect(chef_run).to render_config_file(file.name)

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -211,17 +211,6 @@ neutron.agent.linux.interface.BridgeInterfaceDriver$/,
             .with_section_content('cache', line)
         end
       end
-
-      [
-        /^rabbit_host = 10.0.0.10$/,
-        /^rabbit_userid = guest$/,
-        /^rabbit_password = mq-pass$/,
-      ].each do |line|
-        it do
-          expect(chef_run).to render_config_file(file.name)
-            .with_section_content('oslo_messaging_rabbit', line)
-        end
-      end
     end
   end
 end

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -121,15 +121,15 @@ neutron_x86\?charset=utf8}
 
   describe '/etc/neutron/l3_agent.ini' do
     let(:file) { chef_run.template('/etc/neutron/l3_agent.ini') }
-    [
-      /^interface_driver = \
-neutron.agent.linux.interface.BridgeInterfaceDriver$/,
-      /^external_network_bridge = $/,
-    ].each do |line|
-      it do
-        expect(chef_run).to render_config_file(file.name)
-          .with_section_content('DEFAULT', line)
-      end
+    it do
+      expect(chef_run).to render_config_file(file.name)
+        .with_section_content(
+          'DEFAULT',
+          /^interface_driver = neutron.agent.linux.interface.BridgeInterfaceDriver$/
+        )
+    end
+    it do
+      expect(chef_run).to_not render_config_file(file.name).with_section_content('DEFAULT', /^external_network_bridge/)
     end
   end
 

--- a/spec/telemetry_spec.rb
+++ b/spec/telemetry_spec.rb
@@ -36,12 +36,13 @@ describe 'osl-openstack::telemetry', telemetry: true do
           /^driver = messagingv2$/
         )
     end
-    it do
-      expect(chef_run).to render_config_file(file.name)
-        .with_section_content(
-          'keystone_authtoken',
-          %r{^auth_url = https://10.0.0.10:5000/v3$}
-        )
+    [
+      %r{^auth_url = https://10.0.0.10:5000/v3$},
+      %r{^auth_uri = https://10.0.0.10:5000/v3$},
+    ].each do |line|
+      it do
+        expect(chef_run).to render_config_file(file.name).with_section_content('keystone_authtoken', line)
+      end
     end
     [
       /^host = 10.0.0.2$/,

--- a/spec/telemetry_spec.rb
+++ b/spec/telemetry_spec.rb
@@ -85,16 +85,5 @@ describe 'osl-openstack::telemetry', telemetry: true do
           .with_section_content('cache', line)
       end
     end
-
-    [
-      /^rabbit_host = 10.0.0.10$/,
-      /^rabbit_userid = guest$/,
-      /^rabbit_password = mq-pass$/,
-    ].each do |line|
-      it do
-        expect(chef_run).to render_config_file(file.name)
-          .with_section_content('oslo_messaging_rabbit', line)
-      end
-    end
   end
 end

--- a/spec/unit/recipes/orchestration_spec.rb
+++ b/spec/unit/recipes/orchestration_spec.rb
@@ -75,6 +75,7 @@ describe 'osl-openstack::orchestration' do
     [
       /^memcached_servers = 10.0.0.10:11211$/,
       %r{^auth_url = https://10.0.0.10:5000/v3$},
+      %r{^auth_uri = https://10.0.0.10:5000/v3$},
     ].each do |line|
       it do
         expect(chef_run).to render_config_file(file.name)

--- a/spec/unit/recipes/orchestration_spec.rb
+++ b/spec/unit/recipes/orchestration_spec.rb
@@ -25,6 +25,12 @@ describe 'osl-openstack::orchestration' do
         expect(chef_run).to render_config_file(file.name).with_section_content('DEFAULT', line)
       end
     end
+    it do
+      expect(chef_run).to render_config_file(file.name).with_section_content('trustee', /^auth_type = v3password$/)
+    end
+    it do
+      expect(chef_run).to_not render_config_file(file.name).with_section_content('trustee', /^auth_plugin =/)
+    end
     %w(heat_api heat_api_cfn heat_api_cloudwatch).each do |service|
       it do
         expect(chef_run).to render_config_file(file.name)

--- a/spec/unit/recipes/orchestration_spec.rb
+++ b/spec/unit/recipes/orchestration_spec.rb
@@ -83,17 +83,6 @@ describe 'osl-openstack::orchestration' do
     end
 
     [
-      /^rabbit_host = 10.0.0.10$/,
-      /^rabbit_userid = guest$/,
-      /^rabbit_password = mq-pass$/,
-    ].each do |line|
-      it do
-        expect(chef_run).to render_config_file(file.name)
-          .with_section_content('oslo_messaging_rabbit', line)
-      end
-    end
-
-    [
       %r{^connection = mysql://heat_x86:heat@10.0.0.10:3306/heat_x86\?charset=utf8$},
     ].each do |line|
       it do

--- a/test/integration/block_storage_controller/serverspec/block_storage_controller_spec.rb
+++ b/test/integration/block_storage_controller/serverspec/block_storage_controller_spec.rb
@@ -17,13 +17,15 @@ describe port('8776') do
 end
 
 describe file('/etc/cinder/cinder.conf') do
-  its(:content) do
-    should contain(/^volume_clear_size = 256$/)
-      .from(/^\[DEFAULT\]$/).to(/^\[/)
-  end
-  its(:content) do
-    should contain(/^volume_group = openstack$/)
-      .from(/^\[DEFAULT\]$/).to(/^\[/)
+  [
+    /^volume_clear_size = 256$/,
+    /^volume_group = openstack$/,
+    /^enable_v1_api = false$/,
+    /^enable_v3_api = true$/,
+  ].each do |line|
+    its(:content) do
+      should contain(line).from(/^\[DEFAULT\]$/).to(/^\[/)
+    end
   end
   its(:content) do
     should contain(/memcached_servers = .*:11211/)

--- a/test/integration/network/serverspec/network_spec.rb
+++ b/test/integration/network/serverspec/network_spec.rb
@@ -41,7 +41,7 @@ end
     end
     its(:content) do
       should contain(/memcached_servers = .*:11211/)
-        .from(/^\[keystone_authtoken\]/).to(/^\[/)
+        .from(/^\[keystone_authtoken\]/).to(/^auth_uri/)
     end
     its(:content) do
       should contain(/driver = messagingv2/)
@@ -52,7 +52,6 @@ end
 
 [
   'interface_driver = neutron.agent.linux.interface.BridgeInterfaceDriver',
-  'external_network_bridge = $',
 ].each do |s|
   describe file('/etc/neutron/l3_agent.ini') do
     its(:content) { should contain(/#{s}/).after(/^\[DEFAULT\]/) }

--- a/test/integration/orchestration/serverspec/orchestration_spec.rb
+++ b/test/integration/orchestration/serverspec/orchestration_spec.rb
@@ -34,6 +34,12 @@ describe file('/etc/heat/heat.conf') do
   its(:content) do
     should contain(/driver = messagingv2/).from(/^\[oslo_messaging_notifications\]$/).to(/^\[/)
   end
+  its(:content) do
+    should contain(/auth_type = v3password/).from(/^\[trustee\]$/).to(/^\[/)
+  end
+  its(:content) do
+    should_not contain(/auth_plugin = v3password/).from(/^\[trustee\]$/).to(/^\[/)
+  end
 end
 
 describe command(


### PR DESCRIPTION
This removes (most) of the deprecation warnings I see in the log files. There's a few exceptions which include things that pull in the package provided config file. I'm going to assume this gets fixed upstream in later releases.

@osuosl-cookbooks/chefs I'd like to get this reviewed soon so that I can rebase this into my Ocata branch and apply fixes there as well.