### PR TITLE
Fix Nova compute filters so they work properly

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -130,9 +130,14 @@ node.default['openstack']['compute']['conf'].tap do |conf|
   conf['filter_scheduler']['enabled_filters'] =
     %w(
       AggregateInstanceExtraSpecsFilter
+      RetryFilter
       AvailabilityZoneFilter
       RamFilter
       ComputeFilter
+      ComputeCapabilitiesFilter
+      ImagePropertiesFilter
+      ServerGroupAntiAffinityFilter
+      ServerGroupAffinityFilter
     ).join(',')
   conf['DEFAULT'].delete('use_neutron')
   conf['DEFAULT']['linuxnet_interface_driver'] = 'nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver'

--- a/spec/compute_controller_spec.rb
+++ b/spec/compute_controller_spec.rb
@@ -62,7 +62,7 @@ describe 'osl-openstack::compute_controller' do
       expect(chef_run).to render_config_file(file.name)
         .with_section_content(
           'filter_scheduler',
-          /^enabled_filters = AggregateInstanceExtraSpecsFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter$/
+          /^enabled_filters = AggregateInstanceExtraSpecsFilter,RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter$/
         )
     end
     it do

--- a/test/integration/compute_controller/inspec/compute_controller_spec.rb
+++ b/test/integration/compute_controller/inspec/compute_controller_spec.rb
@@ -30,7 +30,9 @@ describe ini('/etc/nova/nova.conf') do
   its('DEFAULT.resume_guests_state_on_host_boot') { should cmp 'True' }
   its('DEFAULT.block_device_allocate_retries') { should cmp '120' }
   its('notifications.notify_on_state_change') { should cmp 'vm_and_task_state' }
-  its('filter_scheduler.enabled_filters') { should cmp 'AggregateInstanceExtraSpecsFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter' }
+  its('filter_scheduler.enabled_filters') do
+    should cmp 'AggregateInstanceExtraSpecsFilter,RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter'
+  end
   its('cache.memcache_servers') { should cmp 'controller.example.com:11211' }
   its('keystone_authtoken.memcached_servers') { should cmp 'controller.example.com:11211' }
   its('oslo_messaging_notifications.driver') { should cmp 'messagingv2' }


### PR DESCRIPTION
This finally fixes (I think) the issues we've been having using the
AggregateInstanceExtraSpecsFilter filter which we need for P9/P8 separation.
I've tested this on the production system and so far it seems to be working much
better. This is based on the recommended configuration documented here [1].

[1] https://docs.openstack.org/ocata/config-reference/compute/schedulers.html#host-aggregates