### PR TITLE
Remove resources which restart httpd on every chef run

### DIFF
--- a/recipes/compute_controller.rb
+++ b/recipes/compute_controller.rb
@@ -54,3 +54,9 @@ template '/etc/sysconfig/openstack-nova-novncproxy' do
             key: ::File.join(ssl_dir, 'private', novnc['key_file']))
   notifies :restart, proxy_service
 end
+
+# These will restart apache on every chef run, so let's disable this
+delete_resource(:execute, 'nova-api apache restart')
+delete_resource(:execute, 'nova-api: set-selinux-permissive')
+delete_resource(:execute, 'nova-metadata apache restart')
+delete_resource(:execute, 'nova-metadata: set-selinux-permissive')

--- a/spec/compute_controller_spec.rb
+++ b/spec/compute_controller_spec.rb
@@ -221,4 +221,14 @@ describe 'osl-openstack::compute_controller' do
     expect(chef_run.template('/etc/sysconfig/openstack-nova-novncproxy')).to \
       notify('service[openstack-nova-novncproxy]')
   end
+  [
+    'nova-api apache restart',
+    'nova-api: set-selinux-permissive',
+    'nova-metadata apache restart',
+    'nova-metadata: set-selinux-permissive',
+  ].each do |e|
+    it do
+      expect(chef_run).to_not run_execute(e)
+    end
+  end
 end


### PR DESCRIPTION
I'll need to work on fixing this upstream however this is causing an outage on
many of the API endpoints due to the restart happening.