### PR TITLE
Enable SSD enabled ceph pool for volumes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,7 @@ default['osl-openstack']['compute']['rbd_store_pool'] = 'vms'
 default['osl-openstack']['cinder']['iscsi_role'] = nil
 default['osl-openstack']['cinder']['iscsi_ips'] = []
 default['osl-openstack']['block']['rbd_store_pool'] = 'volumes'
+default['osl-openstack']['block']['rbd_ssd_pool'] = 'volumes_ssd'
 default['osl-openstack']['block']['rbd_store_user'] = 'cinder'
 default['osl-openstack']['block_backup']['rbd_store_pool'] = 'backups'
 default['osl-openstack']['block_backup']['rbd_store_user'] = 'cinder-backup'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -259,7 +259,7 @@ node.override['openstack']['block-storage']['conf'].tap do |conf|
   conf['DEFAULT']['volume_clear_size'] = 256
   conf['DEFAULT']['enable_v3_api'] = true
   if node['osl-openstack']['ceph']
-    conf['DEFAULT']['enabled_backends'] = 'ceph'
+    conf['DEFAULT']['enabled_backends'] = 'ceph,ceph_ssd'
     conf['DEFAULT']['backup_driver'] = 'cinder.backup.drivers.ceph'
     conf['DEFAULT']['backup_ceph_conf'] = '/etc/ceph/ceph.conf'
     conf['DEFAULT']['backup_ceph_user'] = node['osl-openstack']['block_backup']['rbd_store_user']
@@ -278,6 +278,16 @@ node.override['openstack']['block-storage']['conf'].tap do |conf|
     conf['ceph']['rados_connect_timeout'] = -1
     conf['ceph']['rbd_user'] = node['osl-openstack']['block']['rbd_store_user']
     conf['ceph']['rbd_secret_uuid'] = node['ceph']['fsid-secret']
+    conf['ceph_ssd']['volume_driver'] = 'cinder.volume.drivers.rbd.RBDDriver'
+    conf['ceph_ssd']['volume_backend_name'] = 'ceph_ssd'
+    conf['ceph_ssd']['rbd_pool'] = node['osl-openstack']['block']['rbd_ssd_pool']
+    conf['ceph_ssd']['rbd_ceph_conf'] = '/etc/ceph/ceph.conf'
+    conf['ceph_ssd']['rbd_flatten_volume_from_snapshot'] = false
+    conf['ceph_ssd']['rbd_max_clone_depth'] = 5
+    conf['ceph_ssd']['rbd_store_chunk_size'] = 4
+    conf['ceph_ssd']['rados_connect_timeout'] = -1
+    conf['ceph_ssd']['rbd_user'] = node['osl-openstack']['block']['rbd_store_user']
+    conf['ceph_ssd']['rbd_secret_uuid'] = node['ceph']['fsid-secret']
     conf['libvirt']['rbd_user'] = node['osl-openstack']['block']['rbd_store_user']
     conf['libvirt']['rbd_secret_uuid'] = node['ceph']['fsid-secret']
   end

--- a/spec/block_storage_controller_spec.rb
+++ b/spec/block_storage_controller_spec.rb
@@ -86,7 +86,7 @@ describe 'osl-openstack::block_storage_controller' do
       include_context 'common_stubs'
       include_context 'ceph_stubs'
       [
-        /^enabled_backends = ceph$/,
+        /^enabled_backends = ceph,ceph_ssd$/,
         /^backup_driver = cinder.backup.drivers.ceph$/,
         %r{^backup_ceph_conf = /etc/ceph/ceph.conf$},
         /^backup_ceph_user = cinder-backup$/,
@@ -114,6 +114,22 @@ describe 'osl-openstack::block_storage_controller' do
       ].each do |line|
         it do
           expect(chef_run).to render_config_file(file.name).with_section_content('ceph', line)
+        end
+      end
+      [
+        /^volume_driver = cinder.volume.drivers.rbd.RBDDriver$/,
+        /^volume_backend_name = ceph_ssd$/,
+        /^rbd_pool = volumes_ssd$/,
+        %r{rbd_ceph_conf = /etc/ceph/ceph.conf$},
+        /^rbd_flatten_volume_from_snapshot = false$/,
+        /^rbd_max_clone_depth = 5$/,
+        /^rbd_store_chunk_size = 4$/,
+        /^rados_connect_timeout = -1$/,
+        /^rbd_user = cinder$/,
+        /^rbd_secret_uuid = 8102bb29-f48b-4f6e-81d7-4c59d80ec6b8$/,
+      ].each do |line|
+        it do
+          expect(chef_run).to render_config_file(file.name).with_section_content('ceph_ssd', line)
         end
       end
       [

--- a/test/cookbooks/openstack_test/recipes/ceph.rb
+++ b/test/cookbooks/openstack_test/recipes/ceph.rb
@@ -1,5 +1,6 @@
 %w(
   volumes
+  volumes_ssd
   images
   backups
   vms
@@ -28,7 +29,7 @@ end
 ceph_chef_client 'cinder' do
   caps(
     mon: 'profile rbd',
-    osd: 'profile rbd pool=volumes, profile rbd pool=vms, profile rbd pool=images'
+    osd: 'profile rbd pool=volumes, profile rbd pool=vms, profile rbd pool=images, profile rbd pool=volumes_ssd'
   )
   group 'ceph'
   key secrets['ceph']['block_token']

--- a/test/integration/block_storage_controller/inspec/block_storage_controller_spec.rb
+++ b/test/integration/block_storage_controller/inspec/block_storage_controller_spec.rb
@@ -21,7 +21,7 @@ describe ini('/etc/cinder/cinder.conf') do
   its('cache.memcache_servers') { should cmp 'controller.example.com:11211' }
   its('keystone_authtoken.memcached_servers') { should cmp 'controller.example.com:11211' }
   its('oslo_messaging_notifications.driver') { should cmp 'messagingv2' }
-  its('DEFAULT.enabled_backends') { should cmp 'ceph' }
+  its('DEFAULT.enabled_backends') { should cmp 'ceph,ceph_ssd' }
   its('DEFAULT.backup_driver') { should cmp 'cinder.backup.drivers.ceph' }
   its('DEFAULT.backup_ceph_conf') { should cmp '/etc/ceph/ceph.conf' }
   its('DEFAULT.backup_ceph_user') { should cmp 'cinder-backup' }
@@ -40,6 +40,16 @@ describe ini('/etc/cinder/cinder.conf') do
   its('ceph.rados_connect_timeout') { should cmp '-1' }
   its('ceph.rbd_user') { should cmp 'cinder' }
   its('ceph.rbd_secret_uuid') { should cmp 'ae3f1d03-bacd-4a90-b869-1a4fabb107f2' }
+  its('ceph_ssd.volume_driver') { should cmp 'cinder.volume.drivers.rbd.RBDDriver' }
+  its('ceph_ssd.volume_backend_name') { should cmp 'ceph_ssd' }
+  its('ceph_ssd.rbd_pool') { should cmp 'volumes_ssd' }
+  its('ceph_ssd.rbd_ceph_conf') { should cmp '/etc/ceph/ceph.conf' }
+  its('ceph_ssd.rbd_flatten_volume_from_snapshot') { should cmp 'false' }
+  its('ceph_ssd.rbd_max_clone_depth') { should cmp '5' }
+  its('ceph_ssd.rbd_store_chunk_size') { should cmp '4' }
+  its('ceph_ssd.rados_connect_timeout') { should cmp '-1' }
+  its('ceph_ssd.rbd_user') { should cmp 'cinder' }
+  its('ceph_ssd.rbd_secret_uuid') { should cmp 'ae3f1d03-bacd-4a90-b869-1a4fabb107f2' }
   its('libvirt.rbd_user') { should cmp 'cinder' }
   its('libvirt.rbd_secret_uuid') { should cmp 'ae3f1d03-bacd-4a90-b869-1a4fabb107f2' }
 end


### PR DESCRIPTION
This creates a second ceph backend which will point to a ceph pool on SSDs.
We'll intend on doing this on both clusters.