### PR TITLE
Temporarily disable memcached for the metadata agent

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -394,7 +394,6 @@ end
   network
   network_dhcp
   network_l3
-  network_metadata
   network_metering
   orchestration
   telemetry

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -197,7 +197,6 @@ neutron.agent.linux.interface.BridgeInterfaceDriver$/,
     neutron.conf
     l3_agent.ini
     dhcp_agent.ini
-    metadata_agent.ini
     metering_agent.ini
   ).each do |f|
     describe "/etc/neutron/#{f}" do

--- a/test/integration/network/inspec/network_spec.rb
+++ b/test/integration/network/inspec/network_spec.rb
@@ -27,7 +27,6 @@ end
   neutron.conf
   l3_agent.ini
   dhcp_agent.ini
-  metadata_agent.ini
 ).each do |f|
   describe ini("/etc/neutron/#{f}") do
     its('cache.memcache_servers') { should cmp 'controller.example.com:11211' }


### PR DESCRIPTION
We currently are experiencing issues where when several VMs are deployed at
once, the metadata server returns a 404 when the VMs boots up. This is a
temporary work around until we figure out a true fix. This may slow down
instance deployments a little but at least they *will* get deployed properly.