### PR TITLE
Increase max client settings for libvirtd

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -115,10 +115,9 @@ resource "openstack_compute_instance_v2" "compute" {
         version         = "14"
     }
 
-    # Run restart libvirtd and run chef-client again
+    # Run chef-client again
     provisioner "remote-exec" {
         inline = [
-            "sudo systemctl restart libvirtd",
             "sudo chef-client"
         ]
         connection {

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -91,7 +91,6 @@ if node['osl-openstack']['ceph']
     directory d do
       owner 'qemu'
       group 'libvirt'
-      notifies :restart, 'service[libvirt-bin]'
     end
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -130,6 +130,12 @@ node.default['openstack']['image_api']['conf'].tap do |conf|
     conf['glance_store']['rbd_store_chunk_size'] = 8
   end
 end
+node.default['openstack']['compute']['libvirt']['conf'].tap do |conf|
+  conf['max_clients'] = '200'
+  conf['max_workers'] = '200'
+  conf['max_requests'] = '200'
+  conf['max_client_requests'] = '50'
+end
 node.default['openstack']['compute']['conf'].tap do |conf|
   conf['filter_scheduler']['enabled_filters'] =
     %w(

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -67,6 +67,16 @@ describe 'osl-openstack::compute' do
   it do
     expect(chef_run).to start_service('libvirt-guests')
   end
+  [
+    /^max_clients = 200$/,
+    /^max_workers = 200$/,
+    /^max_requests = 200$/,
+    /^max_client_requests = 50$/,
+  ].each do |line|
+    it do
+      expect(chef_run).to render_file('/etc/libvirt/libvirtd.conf').with_content(line)
+    end
+  end
   it do
     expect(chef_run).to create_user_account('nova')
       .with(

--- a/test/integration/compute/inspec/compute_spec.rb
+++ b/test/integration/compute/inspec/compute_spec.rb
@@ -41,11 +41,6 @@ describe command("#{openstack} compute service list -f value -c Binary -c Status
   its('stdout') { should match(/nova-compute enabled up/) }
 end
 
-# Nasty hack to work around issue with virsh commands never completing
-describe command('systemctl restart libvirtd') do
-  its('exit_status') { should eq 0 }
-end
-
 describe command('virsh secret-list') do
   its('stdout') do
     should match(/ae3f1d03-bacd-4a90-b869-1a4fabb107f2\s.+ceph client.cinder secret/)
@@ -65,6 +60,13 @@ describe file('/etc/sysconfig/libvirt-guests') do
   its('content') { should match(/^ON_SHUTDOWN=shutdown$/) }
   its('content') { should match(/^PARALLEL_SHUTDOWN=25$/) }
   its('content') { should match(/^SHUTDOWN_TIMEOUT=120$/) }
+end
+
+describe file('/etc/libvirt/libvirtd.conf') do
+  its('content') { should match(/^max_clients = 200$/) }
+  its('content') { should match(/^max_workers = 200$/) }
+  its('content') { should match(/^max_requests = 200$/) }
+  its('content') { should match(/^max_client_requests = 50$/) }
 end
 
 describe file('/var/lib/nova/.ssh/authorized_keys') do

--- a/test/integration/multi-node/controls/compute_spec.rb
+++ b/test/integration/multi-node/controls/compute_spec.rb
@@ -73,11 +73,6 @@ control 'compute' do
     its('stdout') { should match(/nova-compute enabled up/) }
   end
 
-  # Nasty hack to work around issue with virsh commands never completing
-  describe command('systemctl restart libvirtd') do
-    its('exit_status') { should eq 0 }
-  end
-
   describe command('virsh secret-list') do
     its('stdout') do
       should match(/ae3f1d03-bacd-4a90-b869-1a4fabb107f2\s.+ceph client.cinder secret/)


### PR DESCRIPTION
This is needed for ceilometer to be able to poll libvirtd. I believe this is
also the reason we've had problems recently related to libvirtd.