### PR TITLE
Remove multi-store configuration from glance to fix snapshots

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -91,14 +91,13 @@ node.default['openstack']['image_api']['conf'].tap do |conf|
     # [2] https://docs.openstack.org/releasenotes/glance/ocata.html#relnotes-14-0-0-origin-stable-ocata-other-notes
     # [3] https://wiki.openstack.org/wiki/OSSN/OSSN-0065
     conf['DEFAULT']['show_multiple_locations'] = true
-    conf['DEFAULT']['enabled_backends'] = 'cheap:rbd'
     conf['paste_deploy']['flavor'] = 'keystone'
-    conf['glance_store']['default_backend'] = 'cheap'
-    conf['cheap']['store_description'] = 'Cheap rbd backend'
-    conf['cheap']['rbd_store_pool'] = node['osl-openstack']['image']['rbd_store_pool']
-    conf['cheap']['rbd_store_user'] = node['osl-openstack']['image']['rbd_store_user']
-    conf['cheap']['rbd_store_ceph_conf'] = '/etc/ceph/ceph.conf'
-    conf['cheap']['rbd_store_chunk_size'] = 8
+    conf['glance_store']['stores'] = 'rbd'
+    conf['glance_store']['default_store'] = 'rbd'
+    conf['glance_store']['rbd_store_pool'] = node['osl-openstack']['image']['rbd_store_pool']
+    conf['glance_store']['rbd_store_user'] = node['osl-openstack']['image']['rbd_store_user']
+    conf['glance_store']['rbd_store_ceph_conf'] = '/etc/ceph/ceph.conf'
+    conf['glance_store']['rbd_store_chunk_size'] = 8
   end
 end
 node.default['openstack']['compute']['libvirt']['conf'].tap do |conf|

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -84,7 +84,6 @@ describe 'osl-openstack::image', image: true do
         [
           /^show_image_direct_url = true$/,
           /^show_multiple_locations = true$/,
-          /^enabled_backends = cheap:rbd$/,
         ].each do |line|
           it do
             expect(chef_run).to render_config_file(file.name).with_section_content('DEFAULT', line)
@@ -98,21 +97,15 @@ describe 'osl-openstack::image', image: true do
           end
         end
         [
-          /^default_backend = cheap$/,
-        ].each do |line|
-          it do
-            expect(chef_run).to render_config_file(file.name).with_section_content('glance_store', line)
-          end
-        end
-        [
-          /^store_description = Cheap rbd backend$/,
+          /^stores = rbd$/,
+          /^default_store = rbd$/,
           /^rbd_store_pool = images$/,
           /^rbd_store_user = glance$/,
           %r{^rbd_store_ceph_conf = /etc/ceph/ceph.conf$},
           /^rbd_store_chunk_size = 8$/,
         ].each do |line|
           it do
-            expect(chef_run).to render_config_file(file.name).with_section_content('cheap', line)
+            expect(chef_run).to render_config_file(file.name).with_section_content('glance_store', line)
           end
         end
         context 'no image_token' do

--- a/test/integration/allinone/inspec/allinone_spec.rb
+++ b/test/integration/allinone/inspec/allinone_spec.rb
@@ -1,16 +1,3 @@
-describe command('bash -c "source /root/openrc && openstack stack create -t /tmp/heat.yml stack"') do
-  its('exit_status') { should eq 0 }
-end
-
-describe command('bash -c "source /root/openrc && openstack stack show stack -c stack_status -f value"') do
-  its('exit_status') { should eq 0 }
-  its('stdout') { should match(/^CREATE_IN_PROGRESS|CREATE_COMPLETE$/) }
-end
-
-describe command('bash -c "source /root/openrc && openstack stack delete -y  stack"') do
-  its('exit_status') { should eq 0 }
-end
-
 %w(
   check_cinder_api_v2
   check_cinder_api_v3
@@ -25,11 +12,38 @@ end
   end
 end
 
-describe command('bash -c "source /root/openrc && openstack server create --image cirros --flavor m1.nano test"') do
+describe command('bash -c "source /root/openrc && openstack server create --wait --image cirros --flavor m1.nano test"') do
   its('exit_status') { should eq 0 }
-  its('stdout') { should match /OS-EXT-STS:vm_state.*building/ }
+  its('stdout') { should match /OS-EXT-STS:vm_state.*active/ }
 end
 
-describe command('bash -c "source /root/openrc && openstack server delete test"') do
+describe command('bash -c "source /root/openrc && openstack server image create --wait test"') do
+  its('exit_status') { should eq 0 }
+end
+
+describe command('bash -c "source /root/openrc && openstack image show -f shell test"') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /properties=.*image_type='snapshot'/ }
+  its('stdout') { should match /status="active"/ }
+end
+
+describe command('bash -c "source /root/openrc && openstack image delete test"') do
+  its('exit_status') { should eq 0 }
+end
+
+describe command('bash -c "source /root/openrc && openstack server delete --wait test"') do
+  its('exit_status') { should eq 0 }
+end
+
+describe command('bash -c "source /root/openrc && openstack stack create -t /tmp/heat.yml stack"') do
+  its('exit_status') { should eq 0 }
+end
+
+describe command('bash -c "source /root/openrc && openstack stack show stack -c stack_status -f value"') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/^CREATE_IN_PROGRESS|CREATE_COMPLETE$/) }
+end
+
+describe command('bash -c "source /root/openrc && openstack stack delete -y  stack"') do
   its('exit_status') { should eq 0 }
 end


### PR DESCRIPTION
It seems as though multi-store is not complete yet and has some issues related
to creating snapshots of servers. This partially reverts 60212e13. In addition,
add an InSpec test to ensure we can create snapshots so we catch this in the
future.