### PR TITLE
Add prometheus cronjob for listing all projects/instances

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -64,3 +64,4 @@ default['osl-openstack']['novnc'] = {
   'key_file' => 'novnc.key',
 }
 default['osl-openstack']['external_networks'] = %w(public)
+default['osl-openstack']['cluster_name'] = nil

--- a/files/default/openstack-prometheus
+++ b/files/default/openstack-prometheus
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Output current projects and instances in Prometheus format
+mkdir -p /var/lib/node_exporter/
+PROM_FILE=/var/lib/node_exporter/openstack.prom
+OS_PROJECTS=/var/lib/node_exporter/openstack-project-$$.txt
+OS_INSTANCES=/var/lib/node_exporter/openstack-instances-$$.txt
+OS_PROJECTS_FILE=/var/lib/node_exporter/openstack-projects-$$.csv
+OS_INSTANCES_FILE=/var/lib/node_exporter/openstack-instances-$$.csv
+OS_CLUSTER="$(cat /usr/local/etc/os_cluster)"
+
+cat << EOF > ${PROM_FILE}.$$
+# HELP openstack_start_time Start timestamp
+# TYPE openstack_start_time gauge
+openstack_start_time $(date +%s)
+EOF
+
+cat << EOF > ${OS_PROJECTS}
+# HELP openstack_projects Enabled projects
+# TYPE openstack_projects gauge
+EOF
+cat << EOF > ${OS_INSTANCES}
+# HELP openstack_instances VM instances
+# TYPE openstack_instances gauge
+EOF
+
+source /root/openrc
+openstack project list -f csv --quote none --long -c ID -c Name -c Enabled | \
+  grep -v "ID,Name,Enabled" > $OS_PROJECTS_FILE
+
+openstack server list -f csv --quote none --all-projects --long -c ID -c Name \
+  -c Status -c Power\ State -c Host | grep -v "ID,Name,Status,Power State,Host" > $OS_INSTANCES_FILE
+
+while IFS=, read -r id name enabled ; do
+  if [ "${enabled}" == "True" ] ; then
+    state="1"
+  else
+    state="0"
+  fi
+ echo "openstack_projects{cluster=\"${OS_CLUSTER}\",id=\"${id}\",name=\"${name}\"} $state" >> $OS_PROJECTS
+done < $OS_PROJECTS_FILE
+
+while IFS=, read -r id name status power_state host ; do
+  if [ "${status}" == "ACTIVE" ] ; then
+    state="1"
+  else
+    state="0"
+  fi
+ echo "openstack_instances{cluster=\"${OS_CLUSTER}\",id=\"${id}\",name=\"${name}\",power_state=\"${power_state}\",host=\"${host}\"} $state" >> $OS_INSTANCES
+done < $OS_INSTANCES_FILE
+
+cat $OS_PROJECTS $OS_INSTANCES >> ${PROM_FILE}.$$
+
+cat << EOF >> ${PROM_FILE}.$$
+# HELP openstack_completion_time Stop timestamp
+# TYPE openstack_completion_time gauge
+openstack_completion_time $(date +%s)
+EOF
+
+mv ${PROM_FILE}.$$ ${PROM_FILE}
+rm -f $OS_INSTANCES_FILE $OS_PROJECTS_FILE $OS_PROJECTS $OS_INSTANCES

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -19,6 +19,7 @@ provisioner:
       cluster_role: openstack_tk
       database_suffix: x86
       databag_prefix: x86
+      cluster_name: x86
       endpoint_hostname: controller.example.com
       db_hostname: controller.example.com
       bind_service: 127.0.0.1

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -139,4 +139,19 @@ EOF
       parameters "--ext_network_name #{network}"
     end
   end
+
+  unless node['osl-openstack']['cluster_name'].nil?
+    file '/usr/local/etc/os_cluster' do
+      content "#{node['osl-openstack']['cluster_name']}\n"
+    end
+
+    cookbook_file '/usr/local/libexec/openstack-prometheus' do
+      mode '755'
+    end
+
+    cron 'openstack-prometheus' do
+      command '/usr/local/libexec/openstack-prometheus'
+      minute '*/10'
+    end
+  end
 end

--- a/test/integration/mon_controller/inspec/mon_controller_spec.rb
+++ b/test/integration/mon_controller/inspec/mon_controller_spec.rb
@@ -62,3 +62,16 @@ describe file('/etc/nagios/nrpe.d/check_neutron_floating_ip_public.cfg') do
     should match(%r{command\[check_neutron_floating_ip_public\]=/bin/sudo /usr/lib64/nagios/plugins/check_openstack check_neutron_floating_ip --ext_network_name public$})
   end
 end
+
+describe file '/usr/local/etc/os_cluster' do
+  its('content') { should cmp "x86\n" }
+end
+
+describe file '/usr/local/libexec/openstack-prometheus' do
+  it { should be_executable }
+end
+
+describe crontab 'root' do
+  its('commands') { should include '/usr/local/libexec/openstack-prometheus' }
+  its('minutes') { should cmp '*/10' }
+end


### PR DESCRIPTION
This allows us to link UUID's that come from Ceilometer to actual names.
