### PR TITLE
Split ceph enablement between image, compute and volume services

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,9 @@ default['osl-openstack']['data_bags'] = %w(
   user_passwords
 )
 default['osl-openstack']['credentials']['ceph'] = {}
-default['osl-openstack']['ceph'] = false
+default['osl-openstack']['ceph']['image'] = false
+default['osl-openstack']['ceph']['compute'] = false
+default['osl-openstack']['ceph']['volume'] = false
 default['osl-openstack']['ceph_databag'] = 'ceph'
 default['osl-openstack']['ceph_item'] = 'openstack'
 default['osl-openstack']['cluster_role'] = 'openstack'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,7 +17,10 @@ provisioner:
     base:
       packages: []
     osl-openstack:
-      ceph: true
+      ceph:
+        image: true
+        compute: true
+        volume: true
       cluster_role: openstack_tk
       database_suffix: x86
       databag_prefix: x86

--- a/recipes/block_storage.rb
+++ b/recipes/block_storage.rb
@@ -22,7 +22,7 @@ package 'python2-crypto'
 include_recipe 'osl-openstack'
 include_recipe 'openstack-block-storage::volume'
 include_recipe 'openstack-block-storage::identity_registration'
-include_recipe 'osl-openstack::_block_ceph' if node['osl-openstack']['ceph']
+include_recipe 'osl-openstack::_block_ceph' if node['osl-openstack']['ceph']['volume']
 
 replace_or_add 'log-dir storage' do
   path '/usr/share/cinder/cinder-dist.conf'

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -104,7 +104,7 @@ end
 # This resource is causing issues with virsh so remove it
 delete_resource(:execute, 'Deleting default libvirt network')
 
-if node['osl-openstack']['ceph']
+if node['osl-openstack']['ceph']['compute']
   %w(
     /var/run/ceph/guests
     /var/log/ceph

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -85,7 +85,7 @@ node.default['openstack']['identity']['pipeline']['api_v3'] =
 node.default['openstack']['image_api']['conf'].tap do |conf|
   conf['DEFAULT']['enable_v1_api'] = false
   conf['DEFAULT']['enable_v2_api'] = true
-  if node['osl-openstack']['ceph']
+  if node['osl-openstack']['ceph']['image']
     conf['DEFAULT']['show_image_direct_url'] = true
     # show_multiple_locations will be deprecated soon [1][2][3]
     # [1] https://docs.openstack.org/releasenotes/glance/newton.html#relnotes-13-0-0-origin-stable-newton
@@ -134,7 +134,7 @@ node.default['openstack']['compute']['conf'].tap do |conf|
   conf['DEFAULT']['block_device_allocate_retries'] = 120
   conf['DEFAULT']['compute_monitors'] = 'cpu.virt_driver'
   conf['notifications']['notify_on_state_change'] = 'vm_and_task_state'
-  if node['osl-openstack']['ceph']
+  if node['osl-openstack']['ceph']['compute']
     conf['libvirt']['disk_cachemodes'] = 'network=writeback'
     conf['libvirt']['force_raw_images'] = true
     conf['libvirt']['hw_disk_discard'] = 'unmap'
@@ -390,7 +390,7 @@ node.override['openstack']['block-storage']['conf'].tap do |conf|
   conf['DEFAULT']['volume_group'] = 'openstack'
   conf['DEFAULT']['volume_clear_size'] = 256
   conf['DEFAULT']['enable_v3_api'] = true
-  if node['osl-openstack']['ceph']
+  if node['osl-openstack']['ceph']['volume']
     conf['DEFAULT']['enabled_backends'] = 'ceph,ceph_ssd'
     conf['DEFAULT']['backup_driver'] = 'cinder.backup.drivers.ceph'
     conf['DEFAULT']['backup_ceph_conf'] = '/etc/ceph/ceph.conf'
@@ -670,7 +670,11 @@ package 'python2-urllib3' do
   action :upgrade
 end
 
-include_recipe 'osl-ceph' if node['osl-openstack']['ceph']
+if node['osl-openstack']['ceph']['image'] || \
+   node['osl-openstack']['ceph']['compute'] || \
+   node['osl-openstack']['ceph']['volume']
+  include_recipe 'osl-ceph'
+end
 
 # Needed for accessing neutron when running separate from controller node
 package 'python-memcached'

--- a/recipes/image.rb
+++ b/recipes/image.rb
@@ -23,7 +23,7 @@ osl_firewall_openstack 'osl-openstack'
 include_recipe 'openstack-image::api'
 include_recipe 'openstack-image::identity_registration'
 
-if node['osl-openstack']['ceph']
+if node['osl-openstack']['ceph']['image']
   secrets = openstack_credential_secrets
 
   group 'ceph-image' do

--- a/spec/block_storage_controller_spec.rb
+++ b/spec/block_storage_controller_spec.rb
@@ -95,7 +95,7 @@ describe 'osl-openstack::block_storage_controller' do
     context 'Set ceph' do
       let(:runner) do
         ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
-          node.override['osl-openstack']['ceph'] = true
+          node.override['osl-openstack']['ceph']['volume'] = true
           node.automatic['filesystem2']['by_mountpoint']
         end
       end

--- a/spec/block_storage_spec.rb
+++ b/spec/block_storage_spec.rb
@@ -31,7 +31,7 @@ describe 'osl-openstack::block_storage' do
   context 'Set ceph' do
     let(:runner) do
       ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
-        node.override['osl-openstack']['ceph'] = true
+        node.override['osl-openstack']['ceph']['volume'] = true
         node.automatic['filesystem2']['by_mountpoint']
       end
     end

--- a/spec/compute_controller_spec.rb
+++ b/spec/compute_controller_spec.rb
@@ -192,7 +192,7 @@ describe 'osl-openstack::compute_controller' do
     context 'Set ceph' do
       let(:runner) do
         ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
-          node.override['osl-openstack']['ceph'] = true
+          node.override['osl-openstack']['ceph']['compute'] = true
           node.automatic['filesystem2']['by_mountpoint']
         end
       end

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -143,7 +143,7 @@ Host *
   context 'Set ceph' do
     let(:runner) do
       ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
-        node.override['osl-openstack']['ceph'] = true
+        node.override['osl-openstack']['ceph']['compute'] = true
         node.automatic['filesystem2']['by_mountpoint']
       end
     end
@@ -225,7 +225,7 @@ Host *
     context 'virsh secret exists' do
       let(:runner) do
         ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
-          node.override['osl-openstack']['ceph'] = true
+          node.override['osl-openstack']['ceph']['compute'] = true
           node.automatic['filesystem2']['by_mountpoint']
         end
       end

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -47,7 +47,7 @@ describe 'osl-openstack::image', image: true do
         next unless f == 'api'
         let(:runner) do
           ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
-            node.override['osl-openstack']['ceph'] = true
+            node.override['osl-openstack']['ceph']['image'] = true
             node.automatic['filesystem2']['by_mountpoint']
           end
         end
@@ -114,7 +114,7 @@ describe 'osl-openstack::image', image: true do
           next unless f == 'api'
           let(:runner) do
             ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
-              node.override['osl-openstack']['ceph'] = true
+              node.override['osl-openstack']['ceph']['image'] = true
               node.automatic['filesystem2']['by_mountpoint']
             end
           end

--- a/test/integration/dashboard/controls/dashboard_spec.rb
+++ b/test/integration/dashboard/controls/dashboard_spec.rb
@@ -1,4 +1,6 @@
-include_controls 'osuosl-baseline'
+require_controls 'osuosl-baseline' do
+  control 'ssl-baseline'
+end
 
 control 'openstack-dashboard' do
   %w(80 443).each do |p|

--- a/test/integration/identity/controls/identity_spec.rb
+++ b/test/integration/identity/controls/identity_spec.rb
@@ -1,4 +1,6 @@
-include_controls 'osuosl-baseline'
+require_controls 'osuosl-baseline' do
+  control 'ssl-baseline'
+end
 
 control 'openstack-identity' do
   describe service('httpd') do


### PR DESCRIPTION
For nodes that are configured to use local storage still need to have access to Ceph for glance and cinder. This allows this configuration to work properly on those nodes.

In addition, fix InSpec tests using ssl-baseline.

Signed-off-by: Lance Albertson <lance@osuosl.org>
