### PR TITLE
Include _block_ceph recipe if cinder is using ceph

### DIFF
--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -104,6 +104,9 @@ end
 # This resource is causing issues with virsh so remove it
 delete_resource(:execute, 'Deleting default libvirt network')
 
+# We still need the ceph keys if we're using it for cinder
+include_recipe 'osl-openstack::_block_ceph' if node['osl-openstack']['ceph']['volume']
+
 if node['osl-openstack']['ceph']['compute']
   %w(
     /var/run/ceph/guests
@@ -114,8 +117,6 @@ if node['osl-openstack']['ceph']['compute']
       group 'libvirt'
     end
   end
-
-  include_recipe 'osl-openstack::_block_ceph'
 
   group 'ceph-compute' do
     group_name 'ceph'

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -144,6 +144,7 @@ Host *
     let(:runner) do
       ChefSpec::SoloRunner.new(REDHAT_OPTS) do |node|
         node.override['osl-openstack']['ceph']['compute'] = true
+        node.override['osl-openstack']['ceph']['volume'] = true
         node.automatic['filesystem2']['by_mountpoint']
       end
     end


### PR DESCRIPTION
We still need the ceph keys on the nodes for volume attachments to work.

Signed-off-by: Lance Albertson <lance@osuosl.org>
