### PR TITLE
Misc fixes

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,7 +5,6 @@ solver :ruby, :required
 # OSL Base deps
 cookbook 'base', git: 'git@github.com:osuosl-cookbooks/base'
 cookbook 'ceph-chef', github: 'osuosl-cookbooks/ceph-chef'
-cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
 cookbook 'ibm-power', git: 'git@github.com:osuosl-cookbooks/ibm-power.git'
 cookbook 'osl-apache', git: 'git@github.com:osuosl-cookbooks/osl-apache'
 cookbook 'osl-ceph', git: 'git@github.com:osuosl-cookbooks/osl-ceph'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -48,11 +48,6 @@ provisioner:
       fsid-secret: 'ae3f1d03-bacd-4a90-b869-1a4fabb107f2'
       keyring:
         mon: '/etc/ceph/$cluster.mon.keyring'
-    yum:
-      epel:
-        baseurl: http://epel.osuosl.org/7/$basearch
-        enabled: true
-        gpgkey: http://epel.osuosl.org/RPM-GPG-KEY-EPEL-7
     omnibus_updater:
       disabled: true
 

--- a/recipes/block_storage.rb
+++ b/recipes/block_storage.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: block_storage
 #
-# Copyright:: 2015-2021, Oregon State University
+# Copyright:: 2015-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/block_storage_controller.rb
+++ b/recipes/block_storage_controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: block_storage_controller
 #
-# Copyright:: 2016-2021, Oregon State University
+# Copyright:: 2016-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -101,9 +101,6 @@ delete_lines 'remove force_dhcp_release on compute' do
   notifies :restart, 'service[nova-compute]'
 end
 
-# This resource is causing issues with virsh so remove it
-delete_resource(:execute, 'Deleting default libvirt network')
-
 # We still need the ceph keys if we're using it for cinder
 include_recipe 'osl-openstack::_block_ceph' if node['osl-openstack']['ceph']['volume']
 

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: compute
 #
-# Copyright:: 2014-2021, Oregon State University
+# Copyright:: 2014-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/compute_controller.rb
+++ b/recipes/compute_controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: compute_controller
 #
-# Copyright:: 2016-2021, Oregon State University
+# Copyright:: 2016-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/compute_controller.rb
+++ b/recipes/compute_controller.rb
@@ -54,8 +54,6 @@ proxy_service = "service[#{platform_options['compute_vncproxy_service']}]"
 ssl_dir = node['osl-openstack']['nova_ssl_dir']
 novnc = node['osl-openstack']['novnc']
 
-directory '/etc/nova/pki'
-
 certificate_manage 'novnc' do
   cert_path ssl_dir
   cert_file novnc['cert_file']

--- a/recipes/controller.rb
+++ b/recipes/controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: controller
 #
-# Copyright:: 2014-2021, Oregon State University
+# Copyright:: 2014-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/dashboard.rb
+++ b/recipes/dashboard.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: dashboard
 #
-# Copyright:: 2016-2021, Oregon State University
+# Copyright:: 2016-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -644,6 +644,10 @@ end
 include_recipe 'base::packages'
 include_recipe 'osl-repos::epel'
 
+# TODO: These packages conflict with Stein
+r = resources(osl_repos_epel: 'default')
+r.exclude = [r.exclude, %w(python2-pyngus qpid-proton-c)].flatten
+
 package %w(
   libffi-devel
   openssl-devel

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: default
 #
-# Copyright:: 2014-2021, Oregon State University
+# Copyright:: 2014-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/identity.rb
+++ b/recipes/identity.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: identity
 #
-# Copyright:: 2016-2021, Oregon State University
+# Copyright:: 2016-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/image.rb
+++ b/recipes/image.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: image
 #
-# Copyright:: 2016-2021, Oregon State University
+# Copyright:: 2016-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/linuxbridge.rb
+++ b/recipes/linuxbridge.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: linuxbridge
 #
-# Copyright:: 2015-2021, Oregon State University
+# Copyright:: 2015-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: mon
 #
-# Copyright:: 2014-2021, Oregon State University
+# Copyright:: 2014-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/network.rb
+++ b/recipes/network.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: network
 #
-# Copyright:: 2016-2021, Oregon State University
+# Copyright:: 2016-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/ops_database.rb
+++ b/recipes/ops_database.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: ops_database
 #
-# Copyright:: 2015-2021, Oregon State University
+# Copyright:: 2015-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/ops_messaging.rb
+++ b/recipes/ops_messaging.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: ops_messaging
 #
-# Copyright:: 2016-2021, Oregon State University
+# Copyright:: 2016-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/orchestration.rb
+++ b/recipes/orchestration.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: orchestration
 #
-# Copyright:: 2017-2021, Oregon State University
+# Copyright:: 2017-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/telemetry.rb
+++ b/recipes/telemetry.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: telemetry
 #
-# Copyright:: 2016-2021, Oregon State University
+# Copyright:: 2016-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/upgrade.rb
+++ b/recipes/upgrade.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: upgrade
 #
-# Copyright:: 2017-2021, Oregon State University
+# Copyright:: 2017-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/compute_controller_spec.rb
+++ b/spec/compute_controller_spec.rb
@@ -262,10 +262,6 @@ describe 'osl-openstack::compute_controller' do
     end
   end
 
-  it 'creates /etc/nova/pki directory' do
-    expect(chef_run).to create_directory('/etc/nova/pki')
-  end
-
   it 'creates novnc certificate resource' do
     expect(chef_run).to create_certificate_manage('novnc')
   end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -81,6 +81,9 @@ describe 'osl-openstack::default' do
   it do
     expect(chef_run).to install_package('python-memcached')
   end
+  it do
+    expect(chef_run).to add_osl_repos_epel('default').with(exclude: %w(python2-pyngus qpid-proton-c))
+  end
 
   [
     %r{^export OS_CACERT="/etc/ssl/certs/ca-bundle.crt"$},

--- a/test/integration/roles/ceph.json
+++ b/test/integration/roles/ceph.json
@@ -37,12 +37,6 @@
     },
     "osl-ceph": {
       "create-filesystem-osd": true
-    },
-    "yum": {
-      "epel": {
-        "baseurl": "http://epel.osuosl.org/7/$basearch",
-        "gpgkey": "http://epel.osuosl.org/RPM-GPG-KEY-EPEL-7"
-      }
     }
   },
   "json_class": "Chef::Role",


### PR DESCRIPTION
- Remove firewall cookbook
- Cookstyle fixes
- Remove epel attributes
- Exclude python2-pyngus qpid-proton-c in EPEL
- Make sure we remove the default libvirt network
- This is no longer needed with the newer certificate cookbook
