### PR TITLE
Re-enable multi-node testing / refactor upgrade suite

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -220,13 +220,11 @@ suites:
             create_volume_group: true
   - name: upgrade
     driver_config:
-      flavor_ref: 'm1.large'
+      flavor_ref: 'm1.xlarge'
       server_name: "upgrade-<%= ENV['USER'] %>"
-    driver:
-      image_ref: "openstack-rocky-aio"
     verifier:
       inspec_tests:
-        - path: test/integration/controller/inspec
+        - path: test/integration/controller
     run_list:
       - role[ceph]
       - role[ceph_mon]
@@ -235,8 +233,10 @@ suites:
       - role[ceph_setup]
       - recipe[openstack_test::upgrade_start]
       - role[openstack_tk]
+      - recipe[osl-openstack::ops_database]
+      - recipe[certificate::wildcard]
+      - recipe[openstack_test::cacert]
       - recipe[openstack-ops-database::openstack-db]
-      - recipe[osl-openstack::upgrade]
       - recipe[openstack_test::upgrade]
       - recipe[openstack_test]
       - role[openstack_ops_identity]
@@ -253,29 +253,30 @@ suites:
         node_type: controller
         endpoint_hostname: controller.example.com
         db_hostname: controller.example.com
+        upgrade: <%= ENV['OPENSTACK_UPGRADE'] || true %>
       openstack:
         block-storage:
           volume:
             create_volume_group: true
-#  - name: multi-node
-#    driver:
-#      name: terraform
-#      command_timeout: 3600
-#    provisioner: terraform
-#    verifier:
-#      name: terraform
-#      systems:
-#        - name: controller
-#          backend: ssh
-#          controls:
-#            - controller
-#          hosts_output: controller
-#          user: centos
-#          sudo: true
-#        - name: compute
-#          backend: ssh
-#          controls:
-#            - compute
-#          hosts_output: compute
-#          user: centos
-#          sudo: true
+  - name: multi-node
+    driver:
+      name: terraform
+      command_timeout: 3600
+    provisioner: terraform
+    verifier:
+      name: terraform
+      systems:
+        - name: controller
+          backend: ssh
+          controls:
+            - controller
+          hosts_output: controller
+          user: centos
+          sudo: true
+        - name: compute
+          backend: ssh
+          controls:
+            - compute
+          hosts_output: compute
+          user: centos
+          sudo: true

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+provider "openstack" {
+    version = "~> 1.43.0"
+}
+
 resource "openstack_networking_network_v2" "openstack_network" {
     name            = "openstack_network"
     admin_state_up  = "true"
@@ -40,7 +44,7 @@ resource "openstack_compute_instance_v2" "chef_zero" {
 resource "openstack_compute_instance_v2" "controller" {
     name            = "controller"
     image_name      = "${var.centos_image}"
-    flavor_name     = "m1.large"
+    flavor_name     = "m1.xlarge"
     key_pair        = "${var.ssh_key_name}"
     security_groups = ["default"]
     connection {

--- a/test/cookbooks/openstack_test/recipes/upgrade.rb
+++ b/test/cookbooks/openstack_test/recipes/upgrade.rb
@@ -1,11 +1,9 @@
-execute '/root/upgrade.sh' do
-  live_stream true
-  creates '/root/stein-upgrade-done'
-end
+if node['osl-openstack']['upgrade']
+  include_recipe 'osl-openstack::upgrade'
 
-%w(mariadb-config mariadb-server).each do |p|
-  rpm_package p do
-    options '--nodeps'
-    action :remove
+  execute '/root/upgrade.sh' do
+    live_stream true
+    creates '/root/stein-upgrade-done'
+    only_if { ::File.exist?('/usr/sbin/httpd') }
   end
 end

--- a/test/cookbooks/openstack_test/recipes/upgrade_start.rb
+++ b/test/cookbooks/openstack_test/recipes/upgrade_start.rb
@@ -1,5 +1,3 @@
-execute 'systemctl start httpd'
-
 file '/root/upgrade-test' do
   action :touch
 end

--- a/test/integration/roles/openstack_provisioning.json
+++ b/test/integration/roles/openstack_provisioning.json
@@ -54,7 +54,11 @@
     "osl-openstack": {
       "database_suffix": "x86",
       "databag_prefix": "x86",
-      "ceph": true,
+      "ceph": {
+        "image": true,
+        "compute": true,
+        "volume": true
+      },
       "endpoint_hostname": "controller.example.com",
       "db_hostname": "controller.example.com",
       "nova_public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYOuLkP1F/Sm/dCJAA7kme+ObO4J8x2HrZU40W8QqW4yFqRPKnW5HYLeUpRzIFzWen/LIn6R6lxTfSAnnD8qEEuKbFjH5WRqJYCJeAyaTBTRyU1FHlcTR/EQ/HVZ38TQwCztZgboFb5zmWqYc3/BYBHGA6XeYN5jRcHvZbyaGL+YA1/KPIjpbQfqIPXdHfodoSNX4qQQccYBq2c/rq3Puh7Q9oVph6a2lq0wWsqYyq0vTGHPKFYShVpwDl2Z3c8eB3P7yFRzOR2VNuezJlOgoHz6D/mBObLj1n+yi07bcGbpwAH/rLEyiy4gVdru2qQAcbDL9Yibk96lovim/IH4dV nova-migration",

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,7 @@ variable "centos_atomic_image" {
     default = "CentOS Atomic 7.1902"
 }
 variable "centos_image" {
-    default = "CentOS 7.8"
+    default = "CentOS 7.9"
 }
 variable "ssh_key_name" {
     default = "bootstrap"


### PR DESCRIPTION
This re-enables and fixes the multi-node testing suite.

In addition, refactor the upgrade suite so that we do no rely on a special image to test upgrades. Instead, allow the option of setting up the suite on the previous release and then do the actual upgrade in the new release upgrading to. Since this suite is rarely used this shouldn't be an issue.

Signed-off-by: Lance Albertson <lance@osuosl.org>
