### PR TITLE
Only disable SMT on POWER8

### DIFF
--- a/files/default/rc.local
+++ b/files/default/rc.local
@@ -1,4 +1,13 @@
 #!/bin/bash
-# rc.local managed by Chef. Chagnes will be overwritten
-# Disable smt
-/sbin/ppc64_cpu --smt=off
+# THIS FILE IS ADDED FOR COMPATIBILITY PURPOSES
+#
+# It is highly advisable to create own systemd services or udev rules
+# to run scripts during boot instead of using this file.
+#
+# In contrast to previous versions due to parallel execution during boot
+# this script will NOT be run after all other services.
+#
+# Please note that you must run 'chmod +x /etc/rc.d/rc.local' to ensure
+# that this script will be executed during boot.
+
+touch /var/lock/subsys/local

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -7,6 +7,7 @@ driver:
   user_data: userdata.txt
 provisioner:
   name: chef_zero
+  product_version: 16
   deprecations_as_errors: true
   roles_path: test/integration/roles
   data_bags_path: test/integration/data_bags


### PR DESCRIPTION
Switch to using `smt_off` systemd unit instead of `rc.local`. Go ahead and revert `rc.local` back to normal.

Signed-off-by: Lance Albertson <lance@osuosl.org>
