### PR TITLE
Add feature to only have some provider networks on specific hosts

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -40,6 +40,18 @@ provisioner:
             default: eth1
           compute:
             default: eth1
+        -
+          name: private1
+          controller:
+            default: disabled
+          compute:
+            default: disabled
+        -
+          name: private2
+          controller:
+            default: eth2
+          compute:
+            default: disabled
     openstack:
       compute:
         nova_placement: false

--- a/recipes/linuxbridge.rb
+++ b/recipes/linuxbridge.rb
@@ -23,7 +23,7 @@ node_type = node['osl-openstack']['node_type']
 int_mappings = []
 node['osl-openstack']['physical_interface_mappings'].each do |int|
   interface = int[node_type][node['fqdn']] || int[node_type]['default']
-  int_mappings.push("#{int['name']}:#{interface}")
+  int_mappings.push("#{int['name']}:#{interface}") unless interface == 'disabled'
 end
 
 # Get the IP for the interface we're using VXLAN for

--- a/spec/linuxbridge_spec.rb
+++ b/spec/linuxbridge_spec.rb
@@ -229,6 +229,16 @@ neutron.agent.linux.iptables_firewall.IptablesFirewallDriver$/,
                 'bar.example.org' => 'eth3',
               },
             },
+            {
+              name: 'private',
+              controller: {
+                'default' => 'eth2',
+              },
+              compute: {
+                'default' => 'disabled',
+                'foo.example.org' => 'eth3',
+              },
+            },
           ]
       end
       [
@@ -258,10 +268,58 @@ neutron.agent.linux.iptables_firewall.IptablesFirewallDriver$/,
                 'bar.example.org' => 'eth3',
               },
             },
+            {
+              name: 'private',
+              controller: {
+                'default' => 'eth3',
+              },
+              compute: {
+                'default' => 'disabled',
+                'foo.example.org' => 'eth3',
+              },
+            },
           ]
       end
       [
-        /^physical_interface_mappings = public:eth2$/,
+        /^physical_interface_mappings = public:eth2,private:eth3$/,
+      ].each do |line|
+        it do
+          expect(chef_run).to render_config_file(file.name)
+            .with_section_content('linux_bridge', line)
+        end
+      end
+    end
+    context 'Create a private:eth4 on specific node' do
+      cached(:chef_run) { runner.converge(described_recipe) }
+      before do
+        node.automatic['fqdn'] = 'bar.example.org'
+        node.override['osl-openstack']['physical_interface_mappings'] =
+          [
+            {
+              name: 'public',
+              controller: {
+                'default' => 'eth1',
+                'foo.example.org' => 'eth2',
+              },
+              compute: {
+                'default' => 'eth1',
+                'bar.example.org' => 'eth3',
+              },
+            },
+            {
+              name: 'private',
+              controller: {
+                'default' => 'eth2',
+              },
+              compute: {
+                'default' => 'disabled',
+                'bar.example.org' => 'eth4',
+              },
+            },
+          ]
+      end
+      [
+        /^physical_interface_mappings = public:eth3,private:eth4$/,
       ].each do |line|
         it do
           expect(chef_run).to render_config_file(file.name)

--- a/test/integration/controller/controls/linuxbridge_spec.rb
+++ b/test/integration/controller/controls/linuxbridge_spec.rb
@@ -1,1 +1,20 @@
-../../linuxbridge/inspec/linuxbridge_spec.rb
+describe service('neutron-linuxbridge-agent') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe ini('/etc/neutron/plugins/ml2/linuxbridge_agent.ini') do
+  its('vlans.tenant_network_type') { should cmp 'gre,vxlan' }
+  its('vlans.network_vlan_ranges') { should cmp '' }
+  its('vxlan.enable_vxlan') { should cmp 'true' }
+  its('vxlan.l2_population') { should cmp 'true' }
+  its('vxlan.local_ip') { should match(/(?:[0-9]{1,3}\.){3}[0-9]{1,3}/) }
+  its('agent.polling_interval') { should cmp '2' }
+  its('linux_bridge.physical_interface_mappings') { should cmp 'public:eth1,private2:eth2' }
+  its('securitygroup.enable_security_group') { should cmp 'True' }
+  its('securitygroup.firewall_driver') { should cmp 'neutron.agent.linux.iptables_firewall.IptablesFirewallDriver' }
+end
+
+describe command('systemctl list-dependencies --reverse neutron-linuxbridge-agent') do
+  its('stdout') { should include 'iptables' }
+end

--- a/variables.tf
+++ b/variables.tf
@@ -17,10 +17,10 @@ variable "public_subnet" {
     default = "public2"
 }
 variable "backend_network" {
-    default = "vlan42"
+    default = "backend"
 }
 variable "backend_subnet" {
-    default = "vlan42"
+    default = "backend"
 }
 variable "public_network_id" {
     default = "8dcba61e-5ef8-4e79-953a-ea67a66f32e6"


### PR DESCRIPTION
If the interface is set as "disabled", then it will not include it in the `physical_interface_mappings`. This allows usto use some specific vlans only on specific hosts which is needed for the OpenPOWER Hub.

In addition, update the backend network name in multi-node testing.

Signed-off-by: Lance Albertson <lance@osuosl.org>
