### PR TITLE
Ensure we run osl-apache before openstack-identity::server-apache

### DIFF
--- a/recipes/controller.rb
+++ b/recipes/controller.rb
@@ -35,8 +35,8 @@ osl_firewall_memcached 'osl-openstack' do
 end
 
 include_recipe 'memcached'
-include_recipe 'osl-openstack::identity'
 include_recipe 'osl-apache::default'
+include_recipe 'osl-openstack::identity'
 include_recipe 'osl-openstack::image'
 include_recipe 'osl-openstack::network' unless node['osl-openstack']['separate_network_node']
 include_recipe 'osl-openstack::compute_controller'

--- a/recipes/identity.rb
+++ b/recipes/identity.rb
@@ -22,5 +22,6 @@ include_recipe 'osl-openstack::ops_messaging'
 osl_firewall_openstack 'osl-openstack'
 
 include_recipe 'certificate::wildcard'
+include_recipe 'osl-apache'
 include_recipe 'openstack-identity::server-apache'
 include_recipe 'openstack-identity::registration'

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -60,7 +60,7 @@ describe 'osl-openstack::controller' do
   end
   it do
     expect(chef_run).to install_apache2_install('openstack').with(
-      modules: %w(status alias auth_basic authn_core authn_file authz_core authz_groupfile authz_host authz_user autoindex deflate dir env mime negotiation setenvif log_config logio unixd systemd),
+      modules: %w(status alias auth_basic authn_core authn_file authz_core authz_groupfile authz_host authz_user autoindex deflate dir env negotiation setenvif log_config logio unixd systemd),
       mpm_conf: {
         maxrequestworkers: 10,
         serverlimit: 10,


### PR DESCRIPTION
The recent change we made in osl-apache related to the mime module broke this on new installations.

Signed-off-by: Lance Albertson <lance@osuosl.org>
