### PR TITLE
Do not include base::grub on AlmaLinux 8

### DIFF
--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -78,9 +78,11 @@ end
 
 case node['kernel']['machine']
 when 'ppc64le'
-  node.default['base']['grub']['cmdline'] << %w(kvm_cma_resv_ratio=15)
-  include_recipe 'yum-kernel-osuosl::install' if node['platform_version'].to_i < 8
-  include_recipe 'base::grub'
+  if node['platform_version'].to_i < 8
+    node.default['base']['grub']['cmdline'] << %w(kvm_cma_resv_ratio=15)
+    include_recipe 'yum-kernel-osuosl::install'
+    include_recipe 'base::grub'
+  end
 
   kernel_module 'kvm_pr' do
     action [:install, :load]
@@ -103,8 +105,10 @@ when 'ppc64le'
     action [:enable, :start]
   end if node.read('cpu', 'cpu_model') =~ /POWER8/
 when 'aarch64'
-  include_recipe 'yum-kernel-osuosl::install' if node['platform_version'].to_i < 8
-  include_recipe 'base::grub'
+  if node['platform_version'].to_i < 8
+    include_recipe 'yum-kernel-osuosl::install'
+    include_recipe 'base::grub'
+  end
 when 'x86_64'
   kvm_module =
     if node.read('dmi', 'processor', 'manufacturer') == 'AMD'

--- a/spec/unit/recipes/compute_spec.rb
+++ b/spec/unit/recipes/compute_spec.rb
@@ -170,10 +170,11 @@ describe 'osl-openstack::compute' do
         case pltfrm
         when CENTOS_7
           it { is_expected.to include_recipe 'yum-kernel-osuosl::install' }
+          it { is_expected.to include_recipe 'base::grub' }
         when ALMA_8
           it { is_expected.to_not include_recipe 'yum-kernel-osuosl::install' }
+          it { is_expected.to_not include_recipe 'base::grub' }
         end
-        it { is_expected.to include_recipe 'base::grub' }
         it { is_expected.to_not install_kernel_module('kvm_pr') }
         it { is_expected.to_not load_kernel_module('kvm_pr') }
         it { is_expected.to install_kernel_module('kvm_hv') }
@@ -203,10 +204,11 @@ describe 'osl-openstack::compute' do
         case pltfrm
         when CENTOS_7
           it { is_expected.to include_recipe 'yum-kernel-osuosl::install' }
+          it { is_expected.to include_recipe 'base::grub' }
         when ALMA_8
           it { is_expected.to_not include_recipe 'yum-kernel-osuosl::install' }
+          it { is_expected.to_not include_recipe 'base::grub' }
         end
-        it { is_expected.to include_recipe 'base::grub' }
       end
     end
   end


### PR DESCRIPTION
This was missed when I excluded the custom kernel

Signed-off-by: Lance Albertson <lance@osuosl.org>
