### PR TITLE
Increase ulimit for number of files for rabbitmq-server

### DIFF
--- a/recipes/block_storage.rb
+++ b/recipes/block_storage.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: block_storage
 #
-# Copyright:: 2015-2023, Oregon State University
+# Copyright:: 2015-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/block_storage_common.rb
+++ b/recipes/block_storage_common.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: block_storage_common
 #
-# Copyright:: 2023, Oregon State University
+# Copyright:: 2023-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/block_storage_controller.rb
+++ b/recipes/block_storage_controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: block_storage_controller
 #
-# Copyright:: 2016-2023, Oregon State University
+# Copyright:: 2016-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: compute
 #
-# Copyright:: 2014-2023, Oregon State University
+# Copyright:: 2014-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/compute_common.rb
+++ b/recipes/compute_common.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: compute_common
 #
-# Copyright:: 2023, Oregon State University
+# Copyright:: 2023-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/compute_controller.rb
+++ b/recipes/compute_controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: compute_controller
 #
-# Copyright:: 2016-2023, Oregon State University
+# Copyright:: 2016-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/controller.rb
+++ b/recipes/controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: controller
 #
-# Copyright:: 2014-2023, Oregon State University
+# Copyright:: 2014-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/dashboard.rb
+++ b/recipes/dashboard.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: dashboard
 #
-# Copyright:: 2016-2023, Oregon State University
+# Copyright:: 2016-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/identity.rb
+++ b/recipes/identity.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: identity
 #
-# Copyright:: 2016-2023, Oregon State University
+# Copyright:: 2016-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/image.rb
+++ b/recipes/image.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: image
 #
-# Copyright:: 2016-2023, Oregon State University
+# Copyright:: 2016-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: mon
 #
-# Copyright:: 2014-2023, Oregon State University
+# Copyright:: 2014-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/network.rb
+++ b/recipes/network.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: network
 #
-# Copyright:: 2016-2023, Oregon State University
+# Copyright:: 2016-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/network_common.rb
+++ b/recipes/network_common.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: network_common
 #
-# Copyright:: 2023, Oregon State University
+# Copyright:: 2023-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/network_controller.rb
+++ b/recipes/network_controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: network_controller
 #
-# Copyright:: 2015-2023, Oregon State University
+# Copyright:: 2015-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/ops_database.rb
+++ b/recipes/ops_database.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: ops_database
 #
-# Copyright:: 2015-2023, Oregon State University
+# Copyright:: 2015-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/ops_messaging.rb
+++ b/recipes/ops_messaging.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: ops_messaging
 #
-# Copyright:: 2016-2023, Oregon State University
+# Copyright:: 2016-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/orchestration.rb
+++ b/recipes/orchestration.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: orchestration
 #
-# Copyright:: 2017-2023, Oregon State University
+# Copyright:: 2017-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/telemetry_common.rb
+++ b/recipes/telemetry_common.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: telemetry_common
 #
-# Copyright:: 2023, Oregon State University
+# Copyright:: 2023-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/telemetry_compute.rb
+++ b/recipes/telemetry_compute.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: telemetry
 #
-# Copyright:: 2016-2023, Oregon State University
+# Copyright:: 2016-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/telemetry_controller.rb
+++ b/recipes/telemetry_controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: telemetry_controller
 #
-# Copyright:: 2023, Oregon State University
+# Copyright:: 2023-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/upgrade.rb
+++ b/recipes/upgrade.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: upgrade
 #
-# Copyright:: 2017-2023, Oregon State University
+# Copyright:: 2017-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/messaging.rb
+++ b/resources/messaging.rb
@@ -29,6 +29,16 @@ action :create do
 
   package 'rabbitmq-server'
 
+  osl_systemd_unit_drop_in 'ulimit' do
+    content({
+      'Unit' => {
+        'LimitNOFILE' => 300000,
+      },
+    })
+    unit_name 'rabbitmq-server.service'
+    notifies :restart, 'service[rabbitmq-server]'
+  end
+
   service 'rabbitmq-server' do
     action [:enable, :start]
   end

--- a/spec/unit/recipes/ops_messaging_spec.rb
+++ b/spec/unit/recipes/ops_messaging_spec.rb
@@ -22,6 +22,18 @@ describe 'osl-openstack::ops_messaging' do
       it { is_expected.to accept_osl_firewall_port('amqp').with(osl_only: true) }
       it { is_expected.to accept_osl_firewall_port('rabbitmq_mgt').with(osl_only: true) }
       it { is_expected.to install_package 'rabbitmq-server' }
+
+      it do
+        is_expected.to create_osl_systemd_unit_drop_in('ulimit').with(
+          content: {
+            'Unit' => {
+              'LimitNOFILE' => 300000,
+            },
+          },
+          unit_name: 'rabbitmq-server.service'
+        )
+      end
+
       it { is_expected.to enable_service 'rabbitmq-server' }
       it { is_expected.to start_service 'rabbitmq-server' }
 

--- a/test/integration/ops_messaging/controls/ops_messaging_spec.rb
+++ b/test/integration/ops_messaging/controls/ops_messaging_spec.rb
@@ -28,4 +28,8 @@ control 'ops_messaging' do
   describe command('rabbitmqctl -q list_users') do
     its('stdout') { should match(/openstack.*\[\]/) }
   end
+
+  describe command 'systemctl cat rabbitmq-server' do
+    its('stdout') { should match /^LimitNOFILE = 300000$/ }
+  end
 end


### PR DESCRIPTION
The default setting is not enough and causes the MQ server to fail.

Signed-off-by: Lance Albertson <lance@osuosl.org>
