### PR TITLE
Fix libvirtd listening on tcp on AlmaLinux 8

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -115,6 +115,15 @@ module OSLOpenstack
         end
       end
 
+      def openstack_libvirt_service_name
+        case node['platform_version'].to_i
+        when 7
+          'libvirtd.service'
+        when 8
+          'libvirtd.socket'
+        end
+      end
+
       def openstack_transport_url
         m = os_secrets['messaging']
 

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -57,8 +57,14 @@ cookbook_file '/etc/libvirt/libvirtd.conf' do
 end
 
 service 'libvirtd' do
+  service_name openstack_libvirt_service_name
   action [:enable, :start]
 end
+
+service 'libvirtd-tcp.socket' do
+  action [:enable, :start]
+  subscribes :restart, 'cookbook_file[/etc/libvirt/libvirtd.conf]'
+end if node['platform_version'].to_i >= 8
 
 execute 'Deleting default libvirt network' do
   command 'virsh net-destroy default'

--- a/test/integration/compute/controls/compute_spec.rb
+++ b/test/integration/compute/controls/compute_spec.rb
@@ -12,6 +12,28 @@ control 'compute' do
     end
   end
 
+  if os_release >= 8
+    describe service 'libvirtd.socket' do
+      it { should be_enabled }
+      it { should be_running }
+    end
+    describe service 'libvirtd-tcp.socket' do
+      it { should be_enabled }
+      it { should be_running }
+    end
+  else
+    describe service 'libvirtd.service' do
+      it { should be_enabled }
+      it { should be_running }
+    end
+  end
+
+  describe port 16509 do
+    it { should be_listening }
+    its('protocols') { should cmp 'tcp' }
+    its('addresses') { should cmp '0.0.0.0' }
+  end
+
   describe kernel_module('tun') do
     it { should be_loaded }
   end


### PR DESCRIPTION
On AlmaLinux 8, we use the sytsemd socket activation to run the service
properly.

Signed-off-by: Lance Albertson <lance@osuosl.org>
