### PR TITLE
Switch back to libvirtd.service

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -115,15 +115,6 @@ module OSLOpenstack
         end
       end
 
-      def openstack_libvirt_service_name
-        case node['platform_version'].to_i
-        when 7
-          'libvirtd.service'
-        when 8
-          'libvirtd.socket'
-        end
-      end
-
       def openstack_transport_url
         m = os_secrets['messaging']
 

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -57,7 +57,6 @@ cookbook_file '/etc/libvirt/libvirtd.conf' do
 end
 
 service 'libvirtd' do
-  service_name openstack_libvirt_service_name
   action [:enable, :start]
 end
 

--- a/spec/unit/recipes/compute_spec.rb
+++ b/spec/unit/recipes/compute_spec.rb
@@ -44,8 +44,6 @@ describe 'osl-openstack::compute' do
             sysfsutils
           )
         end
-        it { is_expected.to enable_service('libvirtd').with(service_name: 'libvirtd.service') }
-        it { is_expected.to start_service('libvirtd').with(service_name: 'libvirtd.service') }
         it { is_expected.to_not enable_service 'libvirtd-tcp.socket' }
         it { is_expected.to_not start_service 'libvirtd-tcp.socket' }
       when ALMA_8
@@ -62,8 +60,6 @@ describe 'osl-openstack::compute' do
             sysfsutils
           )
         end
-        it { is_expected.to enable_service('libvirtd').with(service_name: 'libvirtd.socket') }
-        it { is_expected.to start_service('libvirtd').with(service_name: 'libvirtd.socket') }
         it { is_expected.to enable_service 'libvirtd-tcp.socket' }
         it { is_expected.to start_service 'libvirtd-tcp.socket' }
         it do
@@ -74,6 +70,8 @@ describe 'osl-openstack::compute' do
       it { expect(chef_run.link('/usr/bin/qemu-system-x86_64')).to link_to('/usr/libexec/qemu-kvm') }
       it { is_expected.to create_cookbook_file '/etc/libvirt/libvirtd.conf' }
       it { expect(chef_run.cookbook_file('/etc/libvirt/libvirtd.conf')).to notify('service[libvirtd]').to(:restart) }
+      it { is_expected.to enable_service 'libvirtd' }
+      it { is_expected.to start_service 'libvirtd' }
       it { is_expected.to run_execute('Deleting default libvirt network').with(command: 'virsh net-destroy default') }
       it { is_expected.to include_recipe 'osl-openstack::compute_common' }
       it { is_expected.to enable_service 'openstack-nova-compute' }

--- a/test/integration/compute/controls/compute_spec.rb
+++ b/test/integration/compute/controls/compute_spec.rb
@@ -12,20 +12,14 @@ control 'compute' do
     end
   end
 
-  if os_release >= 8
-    describe service 'libvirtd.socket' do
-      it { should be_enabled }
-      it { should be_running }
-    end
-    describe service 'libvirtd-tcp.socket' do
-      it { should be_enabled }
-      it { should be_running }
-    end
-  else
-    describe service 'libvirtd.service' do
-      it { should be_enabled }
-      it { should be_running }
-    end
+  describe service 'libvirtd-tcp.socket' do
+    it { should be_enabled }
+    it { should be_running }
+  end if os_release >= 8
+
+  describe service 'libvirtd.' do
+    it { should be_enabled }
+    it { should be_running }
   end
 
   describe port 16509 do


### PR DESCRIPTION
This actually conflicts with libvirtd.socket which automatically activates when
you just start/enable libvirtd.service.

Signed-off-by: Lance Albertson <lance@osuosl.org>
