### PR TITLE
Set nova user shell on compute nodes

### DIFF
--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -71,6 +71,12 @@ end
 
 include_recipe 'osl-openstack::compute_common'
 
+# Modify shell so migrations work properly with ssh
+user 'nova' do
+  shell '/bin/sh'
+  action :modify
+end
+
 service 'openstack-nova-compute' do
   action [:enable, :start]
   subscribes :restart, 'template[/etc/nova/nova.conf]'

--- a/spec/unit/recipes/compute_spec.rb
+++ b/spec/unit/recipes/compute_spec.rb
@@ -70,6 +70,7 @@ describe 'osl-openstack::compute' do
       it { is_expected.to start_service 'libvirtd' }
       it { is_expected.to run_execute('Deleting default libvirt network').with(command: 'virsh net-destroy default') }
       it { is_expected.to include_recipe 'osl-openstack::compute_common' }
+      it { is_expected.to modify_user('nova').with(shell: '/bin/sh') }
       it { is_expected.to enable_service 'openstack-nova-compute' }
       it { is_expected.to start_service 'openstack-nova-compute' }
       it { expect(chef_run.service('openstack-nova-compute')).to subscribe_to('template[/etc/nova/nova.conf]').on(:restart) }

--- a/test/integration/compute/controls/compute_spec.rb
+++ b/test/integration/compute/controls/compute_spec.rb
@@ -12,6 +12,10 @@ control 'compute' do
     end
   end
 
+  describe user 'nova' do
+    its('shell') { should cmp '/bin/sh' }
+  end
+
   describe service 'libvirtd-tcp.socket' do
     it { should be_enabled }
     it { should be_running }


### PR DESCRIPTION
This was missed from the previous refactor. This is needed so that migrations
work properly.

Signed-off-by: Lance Albertson <lance@osuosl.org>
