### PR TITLE
Add support for POWER10

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
 Metrics/BlockNesting:
   Max: 4
 AllCops:
-  TargetChefVersion: 16.latest
   Exclude:
     - "cookbooks/**/*"
 Chef/Modernize/FoodcriticComments:

--- a/Berksfile
+++ b/Berksfile
@@ -22,7 +22,6 @@ cookbook 'osl-selinux', git: 'git@github.com:osuosl-cookbooks/osl-selinux'
 cookbook 'osl-syslog', git: 'git@github.com:osuosl-cookbooks/osl-syslog'
 cookbook 'resource_from_hash', git: 'git@github.com:osuosl-cookbooks/resource_from_hash'
 cookbook 'yum-kernel-osuosl', git: 'git@github.com:osuosl-cookbooks/yum-kernel-osuosl'
-cookbook 'yum-qemu-ev', git: 'git@github.com:osuosl-cookbooks/yum-qemu-ev'
 
 cookbook 'openstack_test', path: 'test/cookbooks/openstack_test'
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -160,6 +160,14 @@ module OSLOpenstack
         int_mappings
       end
 
+      def openstack_power8?
+        node.read('cpu', 'model_name').to_s.match?(/POWER8/)
+      end
+
+      def openstack_power10?
+        node.read('cpu', 'model_name').to_s.match?(/POWER10/)
+      end
+
       # OpenStack API helpers
       def os_conn
         s = os_secrets

--- a/metadata.rb
+++ b/metadata.rb
@@ -22,7 +22,6 @@ depends 'osl-prometheus'
 depends 'osl-repos'
 depends 'osl-resources'
 depends 'yum-kernel-osuosl'
-depends 'yum-qemu-ev'
 
 supports 'almalinux', '~> 8.0'
 

--- a/recipes/block_storage_common.rb
+++ b/recipes/block_storage_common.rb
@@ -21,7 +21,6 @@ s = os_secrets
 b = s['block-storage']
 auth_endpoint = s['identity']['endpoint']
 
-include_recipe 'yum-qemu-ev'
 include_recipe 'osl-ceph'
 
 package 'openstack-cinder'

--- a/recipes/compute_common.rb
+++ b/recipes/compute_common.rb
@@ -60,6 +60,7 @@ template '/etc/nova/nova.conf' do
     placement_pass: s['placement']['service']['pass'],
     pci_alias: openstack_pci_alias,
     pci_passthrough_whitelist: openstack_pci_passthrough_whitelist,
+    power10: openstack_power10?,
     rbd_secret_uuid: ceph_fsid,
     rbd_user: c['ceph']['rbd_user'],
     service_pass: c['service']['pass'],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -253,7 +253,6 @@ end
 shared_context 'compute_stubs' do
   before do
     stub_command('virsh net-list | grep -q default').and_return(true)
-    stub_command('lscpu | grep "KVM"').and_return(false)
     stub_command('virsh secret-list | grep 8102bb29-f48b-4f6e-81d7-4c59d80ec6b8')
     stub_command('virsh secret-get-value 8102bb29-f48b-4f6e-81d7-4c59d80ec6b8 | grep AQAjbr1aWv+aNBAAoGfqrwX9iSdNmtuvUkwGhA==')
   end

--- a/spec/unit/recipes/block_storage_controller_spec.rb
+++ b/spec/unit/recipes/block_storage_controller_spec.rb
@@ -50,7 +50,6 @@ describe 'osl-openstack::block_storage_controller' do
         end
       end
       it { is_expected.to include_recipe 'osl-openstack::block_storage_common' }
-      it { is_expected.to include_recipe 'yum-qemu-ev' }
       it { is_expected.to install_package 'openstack-cinder' }
       it do
         is_expected.to edit_replace_or_add('log-dir controller').with(

--- a/spec/unit/recipes/compute_controller_spec.rb
+++ b/spec/unit/recipes/compute_controller_spec.rb
@@ -148,6 +148,7 @@ describe 'osl-openstack::compute_controller' do
               pci_alias: nil,
               pci_passthrough_whitelist: nil,
               placement_pass: 'placement',
+              power10: false,
               rbd_secret_uuid: '8102bb29-f48b-4f6e-81d7-4c59d80ec6b8',
               rbd_user: 'cinder',
               service_pass: 'nova',

--- a/spec/unit/recipes/compute_spec.rb
+++ b/spec/unit/recipes/compute_spec.rb
@@ -190,7 +190,7 @@ describe 'osl-openstack::compute' do
           it { is_expected.to_not load_kernel_module('kvm_hv') }
           it { is_expected.to_not enable_service 'smt_off' }
           it { is_expected.to_not start_service 'smt_off' }
-          it { is_expected.to render_file('/etc/nova/nova.conf').with_content(/force_raw_images = False/) }
+          it { is_expected.to render_file('/etc/nova/nova.conf').with_content(/force_raw_images = false/) }
           it { is_expected.to render_file('/etc/nova/nova.conf').with_content(/cpu_mode = none/) }
           it { is_expected.to render_file('/etc/nova/nova.conf').with_content(/disk_cachemodes = file=writeback/) }
         end

--- a/templates/nova.conf.erb
+++ b/templates/nova.conf.erb
@@ -16,7 +16,9 @@ disk_allocation_ratio = <%= @disk_allocation_ratio %>
 <% end -%>
 enabled_apis = osapi_compute,metadata
 <% if @power10 -%>
-force_raw_images = False
+force_raw_images = false
+<% else -%>
+force_raw_images = true
 <% end -%>
 instances_path = /var/lib/nova/instances
 instance_usage_audit_period = hour
@@ -75,7 +77,6 @@ rbd_user = <%= @rbd_user %>
 virt_type = kvm
 <% unless @local_storage -%>
 disk_cachemodes = network=writeback
-force_raw_images = true
 hw_disk_discard = unmap
 images_rbd_ceph_conf = /etc/ceph/ceph.conf
 images_rbd_pool = <%= @images_rbd_pool %>

--- a/templates/nova.conf.erb
+++ b/templates/nova.conf.erb
@@ -15,6 +15,9 @@ cpu_allocation_ratio = <%= @cpu_allocation_ratio %>
 disk_allocation_ratio = <%= @disk_allocation_ratio %>
 <% end -%>
 enabled_apis = osapi_compute,metadata
+<% if @power10 -%>
+force_raw_images = False
+<% end -%>
 instances_path = /var/lib/nova/instances
 instance_usage_audit_period = hour
 instance_usage_audit = True
@@ -60,6 +63,10 @@ username = nova
 www_authenticate_uri = https://<%= @auth_endpoint %>:5000/v3
 
 [libvirt]
+<% if @power10 -%>
+cpu_mode = none
+disk_cachemodes = file=writeback
+<% end -%>
 <% if node['kernel']['machine'] == 'x86_64' -%>
 cpu_model_extra_flags = VMX
 <% end -%>

--- a/test/integration/compute_controller/controls/compute_controller_spec.rb
+++ b/test/integration/compute_controller/controls/compute_controller_spec.rb
@@ -62,6 +62,7 @@ control 'compute-controller' do
     its('DEFAULT.compute_monitors') { should cmp 'cpu.virt_driver' }
     its('DEFAULT.cpu_allocation_ratio') { should_not cmp '' }
     its('DEFAULT.disk_allocation_ratio') { should cmp '1.5' }
+    its('DEFAULT.force_raw_images') { should cmp 'true' }
     its('DEFAULT.instance_usage_audit') { should cmp 'True' }
     its('DEFAULT.instance_usage_audit_period') { should cmp 'hour' }
     its('DEFAULT.resume_guests_state_on_host_boot') { should cmp 'True' }
@@ -80,7 +81,6 @@ control 'compute-controller' do
     its('keystone_authtoken.www_authenticate_uri') { should cmp 'https://controller.example.com:5000/v3' }
     its('libvirt.cpu_model_extra_flags') { should cmp 'VMX' }
     its('libvirt.disk_cachemodes') { should cmp 'network=writeback' }
-    its('libvirt.force_raw_images') { should cmp 'true' }
     its('libvirt.hw_disk_discard') { should cmp 'unmap' }
     its('libvirt.images_rbd_ceph_conf') { should cmp '/etc/ceph/ceph.conf' }
     its('libvirt.images_rbd_pool') { should cmp 'vms' }


### PR DESCRIPTION
- Install special kernel for POWER10 when on a P10 host
- Remove references to yum-qemu-ev cookbook that's no longer used
- Use ohai data instead of output from lspcu for kvm module loading on ppc

Signed-off-by: Lance Albertson <lance@osuosl.org>
