### PR TITLE
Install kernel-6.6 on nodes using pci-passthrough

### DIFF
--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -84,6 +84,17 @@ service 'libvirt-guests' do
   action [:enable, :start]
 end
 
+# Newer kernels are needed on AlmaLinux 8 to get pci-passthrough to work
+if openstack_pci_alias
+  osl_repos_centos_kmods 'osl-openstack' do
+    kernel_6_6 true
+  end
+
+  package 'kernel' do
+    action :upgrade
+  end
+end
+
 case node['kernel']['machine']
 when 'ppc64le'
   include_recipe 'yum-kernel-osuosl::install' if openstack_power10?

--- a/spec/unit/recipes/compute_spec.rb
+++ b/spec/unit/recipes/compute_spec.rb
@@ -149,6 +149,19 @@ describe 'osl-openstack::compute' do
         it { is_expected.to install_kernel_module('kvm_amd').with(options: %w(nested=1)) }
       end
 
+      it { is_expected.to_not add_osl_repos_centos_kmods 'osl-openstack' }
+      it { is_expected.to_not upgrade_package 'kernel' }
+
+      context 'pci passthrough' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm) do |node|
+            node.automatic['fqdn'] = 'node1.example.com'
+          end.converge(described_recipe)
+        end
+        it { is_expected.to add_osl_repos_centos_kmods('osl-openstack').with(kernel_6_6: true) }
+        it { is_expected.to upgrade_package 'kernel' }
+      end
+
       context 'ppc64le' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(pltfrm) do |node|


### PR DESCRIPTION
The stock kernel causes guests to crash when trying to use nvidia-smi inside the
guests.

Signed-off-by: Lance Albertson <lance@osuosl.org>
