### PR TITLE
Various fixes for AlmaLinux 9 and local storage

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ verifier:
   name: inspec
 driver:
   name: openstack
-  flavor_ref: 'm1.large'
+  flavor_ref: 'c2.local.8c8m50d'
   user_data: userdata.txt
 provisioner:
   name: chef_infra
@@ -274,7 +274,7 @@ suites:
   - name: controller
     driver_config:
       server_name: "controller-<%= ENV['USER'] %>"
-      flavor_ref: 'm1.xlarge'
+      flavor_ref: 'r2.local.8c24m100d'
     run_list:
       - recipe[openstack_test]
       - role[openstack_tk]
@@ -296,7 +296,7 @@ suites:
   - name: allinone
     driver_config:
       server_name: "allinone-<%= ENV['USER'] %>"
-      flavor_ref: 'm1.xlarge'
+      flavor_ref: 'r2.local.8c24m100d'
     run_list:
       - recipe[openstack_test]
       - role[openstack_tk]
@@ -327,7 +327,7 @@ suites:
         - test/integration/telemetry_controller
   - name: upgrade
     driver_config:
-      flavor_ref: 'm1.xlarge'
+      flavor_ref: 'r2.local.8c24m100d'
       server_name: "upgrade-<%= ENV['USER'] %>"
     run_list:
       - recipe[openstack_test::upgrade_start]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -105,6 +105,10 @@ module OSLOpenstack
             libvirt
             openstack-nova-compute
             python3-libguestfs
+            qemu-kvm
+            qemu-kvm-device-display-virtio-gpu
+            qemu-kvm-device-display-virtio-gpu-pci
+            qemu-kvm-device-display-virtio-vga
             sg3_utils
             sysfsutils
             virt-win-reg

--- a/spec/unit/recipes/compute_spec.rb
+++ b/spec/unit/recipes/compute_spec.rb
@@ -53,6 +53,10 @@ describe 'osl-openstack::compute' do
             libvirt
             openstack-nova-compute
             python3-libguestfs
+            qemu-kvm
+            qemu-kvm-device-display-virtio-gpu
+            qemu-kvm-device-display-virtio-gpu-pci
+            qemu-kvm-device-display-virtio-vga
             sg3_utils
             sysfsutils
             virt-win-reg
@@ -282,9 +286,9 @@ describe 'osl-openstack::compute' do
           it { is_expected.to_not load_kernel_module('kvm_hv') }
           it { is_expected.to_not enable_service 'smt_off' }
           it { is_expected.to_not start_service 'smt_off' }
-          it { is_expected.to render_file('/etc/nova/nova.conf').with_content(/force_raw_images = false/) }
+          it { is_expected.to_not render_file('/etc/nova/nova.conf').with_content(/force_raw_images = false/) }
           it { is_expected.to render_file('/etc/nova/nova.conf').with_content(/cpu_mode = none/) }
-          it { is_expected.to render_file('/etc/nova/nova.conf').with_content(/disk_cachemodes = file=writeback/) }
+          it { is_expected.to_not render_file('/etc/nova/nova.conf').with_content(/disk_cachemodes = file=writeback/) }
         end
       end
 
@@ -377,6 +381,8 @@ describe 'osl-openstack::compute' do
             }
           )
         end
+        it { is_expected.to render_file('/etc/nova/nova.conf').with_content(/force_raw_images = false/) }
+        it { is_expected.to render_file('/etc/nova/nova.conf').with_content(/disk_cachemodes = file=writeback/) }
       end
     end
   end

--- a/templates/nova.conf.erb
+++ b/templates/nova.conf.erb
@@ -15,7 +15,7 @@ cpu_allocation_ratio = <%= @cpu_allocation_ratio %>
 disk_allocation_ratio = <%= @disk_allocation_ratio %>
 <% end -%>
 enabled_apis = osapi_compute,metadata
-<% if @power10 -%>
+<% if @local_storage -%>
 force_raw_images = false
 <% else -%>
 force_raw_images = true
@@ -73,6 +73,8 @@ www_authenticate_uri = https://<%= @auth_endpoint %>:5000/v3
 [libvirt]
 <% if @power10 -%>
 cpu_mode = none
+<% end -%>
+<% if @local_storage -%>
 disk_cachemodes = file=writeback
 <% end -%>
 <% if node['kernel']['machine'] == 'x86_64' -%>

--- a/test/integration/compute/controls/compute_spec.rb
+++ b/test/integration/compute/controls/compute_spec.rb
@@ -69,6 +69,10 @@ control 'compute' do
         libvirt
         openstack-nova-compute
         python3-libguestfs
+        qemu-kvm
+        qemu-kvm-device-display-virtio-gpu
+        qemu-kvm-device-display-virtio-gpu-pci
+        qemu-kvm-device-display-virtio-vga
         sg3_utils
         sysfsutils
         virt-win-reg


### PR DESCRIPTION
- Install additional qemu-kvm packages that are required
- Update qemu file caching modes for local storage and not just power10
- Update flavor for testing

Signed-off-by: Lance Albertson <lance@osuosl.org>
