### PR TITLE
Only install qemu-kvm-device-display-virtio-vga on x86

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -98,21 +98,23 @@ module OSLOpenstack
             sysfsutils
           )
         when 9
-          %w(
-            device-mapper
-            device-mapper-multipath
-            libguestfs-rescue
-            libvirt
-            openstack-nova-compute
-            python3-libguestfs
-            qemu-kvm
-            qemu-kvm-device-display-virtio-gpu
-            qemu-kvm-device-display-virtio-gpu-pci
-            qemu-kvm-device-display-virtio-vga
-            sg3_utils
-            sysfsutils
-            virt-win-reg
-          )
+          pkgs =
+            %w(
+              device-mapper
+              device-mapper-multipath
+              libguestfs-rescue
+              libvirt
+              openstack-nova-compute
+              python3-libguestfs
+              qemu-kvm
+              qemu-kvm-device-display-virtio-gpu
+              qemu-kvm-device-display-virtio-gpu-pci
+              sg3_utils
+              sysfsutils
+              virt-win-reg
+            )
+          pkgs << 'qemu-kvm-device-display-virtio-vga' if intel?
+          pkgs.sort!
         end
       end
 

--- a/recipes/block_storage.rb
+++ b/recipes/block_storage.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: block_storage
 #
-# Copyright:: 2015-2024, Oregon State University
+# Copyright:: 2015-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/block_storage_common.rb
+++ b/recipes/block_storage_common.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: block_storage_common
 #
-# Copyright:: 2023-2024, Oregon State University
+# Copyright:: 2023-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/block_storage_controller.rb
+++ b/recipes/block_storage_controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: block_storage_controller
 #
-# Copyright:: 2016-2024, Oregon State University
+# Copyright:: 2016-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: compute
 #
-# Copyright:: 2014-2024, Oregon State University
+# Copyright:: 2014-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/compute_common.rb
+++ b/recipes/compute_common.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: compute_common
 #
-# Copyright:: 2023-2024, Oregon State University
+# Copyright:: 2023-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/compute_controller.rb
+++ b/recipes/compute_controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: compute_controller
 #
-# Copyright:: 2016-2024, Oregon State University
+# Copyright:: 2016-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/controller.rb
+++ b/recipes/controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: controller
 #
-# Copyright:: 2014-2024, Oregon State University
+# Copyright:: 2014-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/dashboard.rb
+++ b/recipes/dashboard.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: dashboard
 #
-# Copyright:: 2016-2024, Oregon State University
+# Copyright:: 2016-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/identity.rb
+++ b/recipes/identity.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: identity
 #
-# Copyright:: 2016-2024, Oregon State University
+# Copyright:: 2016-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/image.rb
+++ b/recipes/image.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: image
 #
-# Copyright:: 2016-2024, Oregon State University
+# Copyright:: 2016-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: mon
 #
-# Copyright:: 2014-2024, Oregon State University
+# Copyright:: 2014-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/network.rb
+++ b/recipes/network.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: network
 #
-# Copyright:: 2016-2024, Oregon State University
+# Copyright:: 2016-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/network_common.rb
+++ b/recipes/network_common.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: network_common
 #
-# Copyright:: 2023-2024, Oregon State University
+# Copyright:: 2023-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/network_controller.rb
+++ b/recipes/network_controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: network_controller
 #
-# Copyright:: 2015-2024, Oregon State University
+# Copyright:: 2015-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/ops_database.rb
+++ b/recipes/ops_database.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: ops_database
 #
-# Copyright:: 2015-2024, Oregon State University
+# Copyright:: 2015-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/ops_messaging.rb
+++ b/recipes/ops_messaging.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: ops_messaging
 #
-# Copyright:: 2016-2024, Oregon State University
+# Copyright:: 2016-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/orchestration.rb
+++ b/recipes/orchestration.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: orchestration
 #
-# Copyright:: 2017-2024, Oregon State University
+# Copyright:: 2017-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/telemetry_common.rb
+++ b/recipes/telemetry_common.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: telemetry_common
 #
-# Copyright:: 2023-2024, Oregon State University
+# Copyright:: 2023-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/telemetry_compute.rb
+++ b/recipes/telemetry_compute.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: telemetry
 #
-# Copyright:: 2016-2024, Oregon State University
+# Copyright:: 2016-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/telemetry_controller.rb
+++ b/recipes/telemetry_controller.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: telemetry_controller
 #
-# Copyright:: 2023-2024, Oregon State University
+# Copyright:: 2023-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/upgrade.rb
+++ b/recipes/upgrade.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-openstack
 # Recipe:: upgrade
 #
-# Copyright:: 2017-2024, Oregon State University
+# Copyright:: 2017-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/compute_spec.rb
+++ b/spec/unit/recipes/compute_spec.rb
@@ -245,6 +245,48 @@ describe 'osl-openstack::compute' do
         it { is_expected.to upgrade_package 'kernel' }
       end
 
+      context 'aarch64' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm) do |node|
+            node.automatic['kernel']['machine'] = 'aarch64'
+          end.converge(described_recipe)
+        end
+
+        case pltfrm
+        when ALMA_8
+          it do
+            is_expected.to install_package %w(
+              device-mapper
+              device-mapper-multipath
+              libguestfs-rescue
+              libguestfs-tools
+              libvirt
+              openstack-nova-compute
+              python3-libguestfs
+              sg3_utils
+              sysfsutils
+            )
+          end
+        when ALMA_9
+          it do
+            is_expected.to install_package %w(
+              device-mapper
+              device-mapper-multipath
+              libguestfs-rescue
+              libvirt
+              openstack-nova-compute
+              python3-libguestfs
+              qemu-kvm
+              qemu-kvm-device-display-virtio-gpu
+              qemu-kvm-device-display-virtio-gpu-pci
+              sg3_utils
+              sysfsutils
+              virt-win-reg
+            )
+          end
+        end
+      end
+
       context 'ppc64le' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(pltfrm) do |node|
@@ -260,6 +302,39 @@ describe 'osl-openstack::compute' do
         it { is_expected.to_not enable_service 'smt_off' }
         it { is_expected.to_not start_service 'smt_off' }
 
+        case pltfrm
+        when ALMA_8
+          it do
+            is_expected.to install_package %w(
+              device-mapper
+              device-mapper-multipath
+              libguestfs-rescue
+              libguestfs-tools
+              libvirt
+              openstack-nova-compute
+              python3-libguestfs
+              sg3_utils
+              sysfsutils
+            )
+          end
+        when ALMA_9
+          it do
+            is_expected.to install_package %w(
+              device-mapper
+              device-mapper-multipath
+              libguestfs-rescue
+              libvirt
+              openstack-nova-compute
+              python3-libguestfs
+              qemu-kvm
+              qemu-kvm-device-display-virtio-gpu
+              qemu-kvm-device-display-virtio-gpu-pci
+              sg3_utils
+              sysfsutils
+              virt-win-reg
+            )
+          end
+        end
         context 'power8' do
           cached(:chef_run) do
             ChefSpec::SoloRunner.new(pltfrm) do |node|

--- a/test/integration/compute/controls/compute_spec.rb
+++ b/test/integration/compute/controls/compute_spec.rb
@@ -72,12 +72,13 @@ control 'compute' do
         qemu-kvm
         qemu-kvm-device-display-virtio-gpu
         qemu-kvm-device-display-virtio-gpu-pci
-        qemu-kvm-device-display-virtio-vga
         sg3_utils
         sysfsutils
         virt-win-reg
       )
     end
+
+  os_pkgs << 'qemu-kvm-device-display-virtio-vga' if os_release >= 9 && os.arch == 'x86_64'
 
   os_pkgs.each do |p|
     describe package p do


### PR DESCRIPTION
This package doesn't exist on aarch64 or ppc64le.

Signed-off-by: Lance Albertson <lance@osuosl.org>
