### PR TITLE
Only install/use fog-openstack gem when needed

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,26 +1,7 @@
+source 'https://supermarket.osuosl.org'
 source 'https://supermarket.chef.io'
 
 solver :ruby, :required
-
-# OSL Base deps
-cookbook 'base', git: 'git@github.com:osuosl-cookbooks/base'
-cookbook 'osl-apache', git: 'git@github.com:osuosl-cookbooks/osl-apache'
-cookbook 'osl-ceph', git: 'git@github.com:osuosl-cookbooks/osl-ceph'
-cookbook 'osl-firewall', git: 'git@github.com:osuosl-cookbooks/osl-firewall'
-cookbook 'osl-git', git: 'git@github.com:osuosl-cookbooks/osl-git'
-cookbook 'osl-memcached', git: 'git@github.com:osuosl-cookbooks/osl-memcached'
-cookbook 'osl-mysql', git: 'git@github.com:osuosl-cookbooks/osl-mysql'
-cookbook 'osl-nrpe', git: 'git@github.com:osuosl-cookbooks/osl-nrpe'
-cookbook 'osl-php', git: 'git@github.com:osuosl-cookbooks/osl-php'
-cookbook 'osl-postfix', git: 'git@github.com:osuosl-cookbooks/osl-postfix'
-cookbook 'osl-prometheus', git: 'git@github.com:osuosl-cookbooks/osl-prometheus'
-cookbook 'osl-repos', git: 'git@github.com:osuosl-cookbooks/osl-repos'
-cookbook 'osl-resources', git: 'git@github.com:osuosl-cookbooks/osl-resources', branch: 'main'
-cookbook 'osl-rsync', git: 'git@github.com:osuosl-cookbooks/osl-rsync'
-cookbook 'osl-selinux', git: 'git@github.com:osuosl-cookbooks/osl-selinux'
-cookbook 'osl-syslog', git: 'git@github.com:osuosl-cookbooks/osl-syslog'
-cookbook 'resource_from_hash', git: 'git@github.com:osuosl-cookbooks/resource_from_hash'
-cookbook 'yum-kernel-osuosl', git: 'git@github.com:osuosl-cookbooks/yum-kernel-osuosl'
 
 cookbook 'openstack_test', path: 'test/cookbooks/openstack_test'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -27,5 +27,3 @@ depends 'yum-osuosl'
 
 supports 'almalinux', '~> 8.0'
 supports 'almalinux', '~> 9.0'
-
-gem 'fog-openstack', '~> 1.1'

--- a/test/cookbooks/openstack_test/recipes/cacert.rb
+++ b/test/cookbooks/openstack_test/recipes/cacert.rb
@@ -12,7 +12,9 @@ execute 'copy self-signed ca-cert' do
   creates '/tmp/cacert'
 end
 
-chef_gem 'excon'
+chef_gem 'excon' do
+  compile_time true
+end
 
 # Make sure ruby knows to use the ca-bundle certs as authority so that our self signed cert gets verified properly.
 # NOTE: This is only needed for testing, not production.


### PR DESCRIPTION
One of the gem dependencies (io-console) now requires a compiler to build a
native extension in a newer release. The compute nodes don't currently have a
compiler and it's not needed until we're using one of the resources which
requires the fog-openstack gem.

Using the logic from the postgresql cookbook, this moves the fog-openstack gem
installation out of the metadata.rb and into helper methods. If it is triggered,
then the gcc package will be installed in compile_time (not need to use
build_essential as we only need gcc), and then use chef_gem to install the gem.
This will dynamically require the fog-openstack gem if needed even after
installation.

This should fix any future issues we have with gems that fog-openstack depend on
which may also start needing native extensions.

Signed-off-by: Lance Albertson <lance@osuosl.org>
