### PR TITLE
Attempt to resolve issues with snapshots

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -94,6 +94,7 @@ suites:
       - role[openstack_ops_identity]
       - recipe[osl-openstack::network_controller]
       - recipe[osl-openstack::network]
+      - recipe[openstack_test::create_network]
     verifier:
       inputs:
         compute: true
@@ -143,6 +144,7 @@ suites:
       - recipe[osl-openstack::network]
       - recipe[osl-openstack::compute_controller]
       - recipe[osl-openstack::compute]
+      - recipe[openstack_test::create_network]
     verifier:
       inspec_tests:
         - test/integration/compute
@@ -163,6 +165,7 @@ suites:
       - recipe[osl-openstack::network]
       - recipe[osl-openstack::compute_controller]
       - recipe[osl-openstack::compute]
+      - recipe[openstack_test::create_network]
     verifier:
       inputs:
         local_storage: true
@@ -309,6 +312,7 @@ suites:
       - recipe[osl-openstack::network]
       - recipe[osl-openstack::compute]
       - recipe[openstack_test::image_upload]
+      - recipe[openstack_test::create_network]
     verifier:
       inputs:
         compute: true
@@ -343,6 +347,7 @@ suites:
       - recipe[osl-openstack::network]
       - recipe[osl-openstack::compute]
       - recipe[openstack_test::image_upload]
+      - recipe[openstack_test::create_network]
     verifier:
       inputs:
         compute: true

--- a/main.tf
+++ b/main.tf
@@ -264,7 +264,7 @@ resource "null_resource" "controller" {
             knife bootstrap -c test/chef-config/knife.rb \
                 ${var.ssh_user_name}@${openstack_compute_instance_v2.controller.network.0.fixed_ip_v4} \
                 --bootstrap-version ${var.chef_version} -y -N controller --sudo \
-                -r 'role[openstack_tf_common],role[openstack_controller],recipe[openstack_test::prometheus],recipe[osl-openstack::ops_messaging],recipe[osl-openstack::controller],recipe[osl-openstack::block_storage],recipe[openstack_test::image_upload]'
+                -r 'role[openstack_tf_common],role[openstack_controller],recipe[openstack_test::prometheus],recipe[osl-openstack::ops_messaging],recipe[osl-openstack::controller],recipe[osl-openstack::block_storage],recipe[openstack_test::image_upload],recipe[openstack_test::create_network]'
             EOF
         environment = {
             CHEF_SERVER = "${openstack_compute_instance_v2.chef_zero.network.0.fixed_ip_v4}"
@@ -274,6 +274,9 @@ resource "null_resource" "controller" {
     provisioner "remote-exec" {
         inline = [
             "sudo cinc-client",
+            "sudo /root/image_upload.sh",
+            "sudo /root/create_flavor.sh",
+            "sudo /root/create_network.sh",
         ]
     }
 

--- a/templates/glance-api.conf.erb
+++ b/templates/glance-api.conf.erb
@@ -5,7 +5,7 @@
 enable_v1_api = false
 enable_v2_api = true
 <% unless @local_storage -%>
-enabled_backends = rbd:rbd,http:http
+enabled_backends = rbd:rbd
 show_image_direct_url = true
 show_multiple_locations = true
 <% else -%>
@@ -17,11 +17,9 @@ transport_url = <%= @transport_url %>
 <% unless @local_storage -%>
 default_backend = rbd
 default_store = rbd
-stores = rbd
 <% else -%>
 default_backend = file
 default_store = file
-stores = file
 <% end -%>
 
 <% unless @local_storage -%>

--- a/test/cookbooks/openstack_test/recipes/ceph.rb
+++ b/test/cookbooks/openstack_test/recipes/ceph.rb
@@ -2,6 +2,7 @@ include_recipe 'osl-ceph'
 
 osl_ceph_test 'openstack' do
   create_config false
+  osd_size '10G'
 end
 
 %w(
@@ -25,7 +26,7 @@ secrets = os_secrets
 osl_ceph_client 'glance' do
   caps(
     mon: 'profile rbd',
-    osd: 'profile rbd pool=images'
+    osd: 'profile rbd pool=images, profile rbd-read-only pool=volumes, profile rbd-read-only pool=vms'
   )
   key secrets['image']['ceph']['image_token']
   keyname 'client.glance'

--- a/test/cookbooks/openstack_test/recipes/create_network.rb
+++ b/test/cookbooks/openstack_test/recipes/create_network.rb
@@ -1,13 +1,17 @@
-execute 'create public network' do
-  command <<-EOF
+file '/root/create_network.sh' do
+  mode '0755'
+  content <<~EOF
+    #!/bin/bash
+    set -e
     source /root/openrc
-    openstack network create --share --provider-network-type=flat --provider-physical-network=public \
-      --external --default public
-    openstack subnet create public --network public --subnet-range=10.10.1.0/24 \
-      --allocation-pool=start=10.10.1.2,end=10.10.1.100 --dns-nameserver 140.211.166.130 \
-      --dns-nameserver 140.211.166.131 --gateway 10.10.1.1
-    openstack network set --external public
-    openstack network show -c id -f value public > /var/tmp/public_network
+    if ! [ -f /var/tmp/public_network ] ; then
+      openstack network create --share --provider-network-type=flat --provider-physical-network=public \
+        --external --default public
+      openstack subnet create public --network public --subnet-range=10.10.1.0/24 \
+        --allocation-pool=start=10.10.1.2,end=10.10.1.100 --dns-nameserver 140.211.166.130 \
+        --dns-nameserver 140.211.166.131 --gateway 10.10.1.1
+      openstack network set --external public
+      openstack network show -c id -f value public > /var/tmp/public_network
+    fi
   EOF
-  creates '/var/tmp/public_network'
 end

--- a/test/cookbooks/openstack_test/recipes/image_upload.rb
+++ b/test/cookbooks/openstack_test/recipes/image_upload.rb
@@ -1,8 +1,13 @@
-cirros_img = ::File.join(Chef::Config[:file_cache_path], 'cirros.img')
+alpine_qcow2 = ::File.join(Chef::Config[:file_cache_path], 'alpine.qcow2')
+alpine_img = ::File.join(Chef::Config[:file_cache_path], 'alpine.img')
 
-remote_file cirros_img do
-  source 'http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img'
+remote_file alpine_qcow2 do
+  source 'https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/generic_alpine-3.22.1-x86_64-bios-cloudinit-r0.qcow2'
   show_progress true
+end
+
+execute "qemu-img convert -O raw #{alpine_qcow2} #{alpine_img}" do
+  creates alpine_img
 end
 
 file '/root/image_upload.sh' do
@@ -13,15 +18,28 @@ file '/root/image_upload.sh' do
     source /root/openrc
     if ! [ -f /root/image_upload.done ] ; then
       openstack image create \
-        --file #{cirros_img} \
+        --file #{alpine_img} \
         --disk-format raw \
         --container-format bare \
         --property hw_scsi_model=virtio-scsi \
         --property hw_disk_bus=scsi \
         --property hw_qemu_guest_agent=yes \
         --property os_require_quiesce=yes \
-        cirros
+        alpine
       touch /root/image_upload.done
     fi
   EOC
+end
+
+file '/root/create_flavor.sh' do
+  mode '0755'
+  content <<~EOF
+    #!/bin/bash
+    set -e
+    source /root/openrc
+    if ! [ -f /root/flavor.done ] ; then
+      openstack flavor create --ram 512 --vcpus 1 --disk 1 --public default
+      touch /root/flavor.done
+    fi
+  EOF
 end

--- a/test/integration/image/controls/image_spec.rb
+++ b/test/integration/image/controls/image_spec.rb
@@ -39,15 +39,16 @@ control 'image' do
 
   describe command('/root/image_upload.sh') do
     its('exit_status') { should eq 0 }
+    its('stderr') { should eq '' }
   end
 
   describe command('bash -c "source /root/openrc && /usr/bin/openstack image list"') do
     its('stdout') do
-      should match(/\|\s[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\s\|\scirros.*\s\|\sactive/)
+      should match(/\|\s[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\s\|\salpine.*\s\|\sactive/)
     end
   end
 
-  describe command('bash -c "source /root/openrc && /usr/bin/openstack image show cirros -c properties -f value"') do
+  describe command('bash -c "source /root/openrc && /usr/bin/openstack image show alpine -c properties -f value"') do
     if local_storage
       its('stdout') { should_not match(/direct_url': 'rbd:/) }
       its('stdout') { should_not match(/'locations':/) }
@@ -60,6 +61,17 @@ control 'image' do
   describe command('rbd --id glance ls images') do
     its('stdout') { should match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/) }
   end unless local_storage
+
+  describe command('/root/create_flavor.sh') do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should eq '' }
+  end
+
+  describe command('bash -c "source /root/openrc && /usr/bin/openstack flavor show default -c ram -c vcpus -c disk -f shell"') do
+    its('stdout') { should match(/disk="1"/) }
+    its('stdout') { should match(/ram="512"/) }
+    its('stdout') { should match(/vcpus="1"/) }
+  end
 
   describe user('glance') do
     if local_storage

--- a/test/integration/network/controls/network_spec.rb
+++ b/test/integration/network/controls/network_spec.rb
@@ -143,4 +143,26 @@ control 'network' do
       its('stdout') { should match(/^#{ext}$/) }
     end
   end if controller
+
+  describe command('/root/create_network.sh') do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should eq '' }
+  end if controller
+
+  describe command('bash -c "source /root/openrc && openstack network show public -c admin_state_up -c provider:network_type -c provider:physical_network -c router:external -c is_default -c shared -c status -f shell"') do
+    its('stdout') { should match(/admin_state_up="True"/) }
+    its('stdout') { should match(/is_default="True"/) }
+    its('stdout') { should match(/provider_network_type="flat"/) }
+    its('stdout') { should match(/provider_physical_network="public"/) }
+    its('stdout') { should match(/router_external="True"/) }
+    its('stdout') { should match(/shared="True"/) }
+    its('stdout') { should match(/status="ACTIVE"/) }
+  end if controller
+
+  describe command('bash -c "source /root/openrc && openstack subnet show public -c allocation_pools -c cidr -c dns_nameservers -c gateway_ip -f shell"') do
+    its('stdout') { should match(/allocation_pools="\[{'start': '10.10.1.2', 'end': '10.10.1.100'}\]"/) }
+    its('stdout') { should match(%r{cidr="10.10.1.0/24"}) }
+    its('stdout') { should match(/dns_nameservers="\['140.211.166.130', '140.211.166.131'\]"/) }
+    its('stdout') { should match(/gateway_ip="10.10.1.1"/) }
+  end if controller
 end


### PR DESCRIPTION
This attempts to resolve this ticket [1]. This removes the http backend with
glance so that we only have to deal with one store. This was only useful for
providing the ability of creating images from URL's. Most of our users don't
likely use this feature and it's likely causing more issues.

Additional changes:

- Remove deprecated "stores" config parameter
- Create a network and subnet and add integration tests
- Increase OSD size from 1G to 10G to allow use of Alpine image
- Add read-only access for glance ceph user to volumes and vm
- Create scripts to create network, flavor instead of creating them with chef
  directly
- Switch to using Alpine Linux image as it's known to work and is more modern
- Update tests

[1] https://support.osuosl.org/Ticket/Display.html?id=34243

Signed-off-by: Lance Albertson <lance@osuosl.org>
