### PR TITLE
Fix ProxyCommand to use port 2222 instead of %p

### DIFF
--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -271,7 +271,7 @@ file '/var/lib/nova/.ssh/config' do
     Host *
       StrictHostKeyChecking no
       UserKnownHostsFile /dev/null
-      ProxyCommand /usr/bin/hpnssh -F /var/lib/nova/.ssh/config_hpnssh -W %h:%p %h
+      ProxyCommand /usr/bin/hpnssh -F /var/lib/nova/.ssh/config_hpnssh -W %h:2222 %h
   EOL
   user 'nova'
   group 'nova'

--- a/spec/unit/recipes/compute_spec.rb
+++ b/spec/unit/recipes/compute_spec.rb
@@ -261,7 +261,7 @@ describe 'osl-openstack::compute' do
       end
       it do
         is_expected.to create_file('/var/lib/nova/.ssh/config').with(
-          content: "Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null\n  ProxyCommand /usr/bin/hpnssh -F /var/lib/nova/.ssh/config_hpnssh -W %h:%p %h\n",
+          content: "Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null\n  ProxyCommand /usr/bin/hpnssh -F /var/lib/nova/.ssh/config_hpnssh -W %h:2222 %h\n",
           user: 'nova',
           group: 'nova',
           mode: '600'

--- a/test/integration/compute/controls/compute_spec.rb
+++ b/test/integration/compute/controls/compute_spec.rb
@@ -221,7 +221,7 @@ X0BwCgHRB7FvPAMu0hrDmEIJ87edGd1ziRYXpA9Lke/4VQk249pwzA==
       should cmp("Host *
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
-  ProxyCommand /usr/bin/hpnssh -F /var/lib/nova/.ssh/config_hpnssh -W %h:%p %h\n")
+  ProxyCommand /usr/bin/hpnssh -F /var/lib/nova/.ssh/config_hpnssh -W %h:2222 %h\n")
     end
     its('mode') { should cmp '00600' }
     it { should be_owned_by 'nova' }


### PR DESCRIPTION
The %p variable resolves to the port Nova requests (22), not the hpnssh
port. Hardcode port 2222 in the -W argument so the stdio forwarding
connects to hpnsshd on the remote host.

Signed-off-by: Lance Albertson <lance@osuosl.org>
