### PR TITLE
Add live migration tuning settings to nova.conf

### DIFF
--- a/templates/nova.conf.erb
+++ b/templates/nova.conf.erb
@@ -94,7 +94,11 @@ images_type = rbd
 inject_key = false
 inject_partition = -2
 inject_password = false
+live_migration_downtime = 1000
+live_migration_downtime_delay = 30
 live_migration_flag = VIR_MIGRATE_UNDEFINE_SOURCE,VIR_MIGRATE_PEER2PEER,VIR_MIGRATE_LIVE,VIR_MIGRATE_PERSIST_DEST,VIR_MIGRATE_TUNNELLED
+live_migration_permit_post_copy = true
+live_migration_timeout_action = force_complete
 <% end -%>
 
 [neutron]

--- a/test/integration/compute_controller/controls/compute_controller_spec.rb
+++ b/test/integration/compute_controller/controls/compute_controller_spec.rb
@@ -92,7 +92,11 @@ control 'compute-controller' do
       its('libvirt.inject_key') { should cmp 'false' }
       its('libvirt.inject_partition') { should cmp '-2' }
       its('libvirt.inject_password') { should cmp 'false' }
+      its('libvirt.live_migration_downtime') { should cmp '1000' }
+      its('libvirt.live_migration_downtime_delay') { should cmp '30' }
       its('libvirt.live_migration_flag') { should cmp 'VIR_MIGRATE_UNDEFINE_SOURCE,VIR_MIGRATE_PEER2PEER,VIR_MIGRATE_LIVE,VIR_MIGRATE_PERSIST_DEST,VIR_MIGRATE_TUNNELLED' }
+      its('libvirt.live_migration_permit_post_copy') { should cmp 'true' }
+      its('libvirt.live_migration_timeout_action') { should cmp 'force_complete' }
       its('libvirt.rbd_secret_uuid') { should cmp 'ae3f1d03-bacd-4a90-b869-1a4fabb107f2' }
       its('libvirt.rbd_user') { should cmp 'cinder' }
     end


### PR DESCRIPTION
Add the following libvirt settings for improved live migration completion:
- live_migration_downtime = 1000 (increase pause time to 1s)
- live_migration_downtime_delay = 30 (more aggressive downtime steps)
- live_migration_permit_post_copy = true (guaranteed completion)
- live_migration_timeout_action = force_complete (auto-complete on timeout)

These settings help ensure live migrations complete without manual intervention
when VMs are dirtying memory faster than the network can transfer.

Signed-off-by: Lance Albertson <lance@osuosl.org>
