### PR TITLE
Increase LimitNOFILE for nova-compute to fix "Too many open files"

### DIFF
--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -86,6 +86,19 @@ user 'nova' do
   action :modify
 end
 
+# Increase the file descriptor limit for nova-compute to prevent
+# "Too many open files" errors when using Ceph/RBD storage and
+# eventlet concurrency, which can exhaust the default FD limit.
+osl_systemd_unit_drop_in 'ulimit' do
+  content({
+    'Service' => {
+      'LimitNOFILE' => 1048576,
+    },
+  })
+  unit_name 'openstack-nova-compute.service'
+  notifies :restart, 'service[openstack-nova-compute]'
+end
+
 service 'openstack-nova-compute' do
   action [:enable, :start]
   subscribes :restart, 'template[/etc/nova/nova.conf]'

--- a/spec/unit/recipes/compute_spec.rb
+++ b/spec/unit/recipes/compute_spec.rb
@@ -128,6 +128,18 @@ describe 'osl-openstack::compute' do
       it { is_expected.to_not render_file('/etc/nova/nova.conf').with_content(/disk_cachemodes = file=writeback/) }
       it { is_expected.to_not include_recipe 'yum-kernel-osuosl::install' }
       it { is_expected.to modify_user('nova').with(shell: '/bin/sh') }
+
+      it do
+        is_expected.to create_osl_systemd_unit_drop_in('ulimit').with(
+          content: {
+            'Service' => {
+              'LimitNOFILE' => 1048576,
+            },
+          },
+          unit_name: 'openstack-nova-compute.service'
+        )
+      end
+
       it { is_expected.to enable_service 'openstack-nova-compute' }
       it { is_expected.to start_service 'openstack-nova-compute' }
       it { expect(chef_run.service('openstack-nova-compute')).to subscribe_to('template[/etc/nova/nova.conf]').on(:restart) }

--- a/test/integration/compute/controls/compute_spec.rb
+++ b/test/integration/compute/controls/compute_spec.rb
@@ -228,6 +228,10 @@ X0BwCgHRB7FvPAMu0hrDmEIJ87edGd1ziRYXpA9Lke/4VQk249pwzA==
     it { should be_grouped_into 'nova' }
   end
 
+  describe command 'systemctl cat openstack-nova-compute' do
+    its('stdout') { should match /^LimitNOFILE = 1048576$/ }
+  end
+
   describe service('hpnsshd') do
     it { should be_enabled }
     it { should be_running }


### PR DESCRIPTION
Add a systemd drop-in override for openstack-nova-compute.service that
sets LimitNOFILE to 1048576. This prevents OSError EMFILE errors caused
by Ceph/RBD storage and eventlet concurrency exhausting the default
file descriptor limit on AlmaLinux 9.

Signed-off-by: Lance Albertson <lance@osuosl.org>
