### PR TITLE
HA: handle encrypted data bags, accept CIDR VIPs, drop haproxy stub, fix NRPE checks

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -209,6 +209,16 @@ module OSLOpenstack
         safe_dig(ha, 'api_listen_ip', node['fqdn']) || '*'
       end
 
+      # Concrete IP that local healthchecks (NRPE etc.) should connect to
+      # in order to hit *this* node's API daemons directly, bypassing
+      # the VIP / HAProxy. On HA controllers Apache binds the per-host
+      # private IP (ha.api_listen_ip[node['fqdn']]); on non-HA
+      # single-controller deploys Apache binds wildcard, so
+      # node['ipaddress'] is the right local target.
+      def openstack_local_api_endpoint
+        safe_dig(os_secrets, 'ha', 'api_listen_ip', node['fqdn']) || node['ipaddress']
+      end
+
       # Comma-joined glance endpoint URLs for nova/cinder. Accepts either
       # a single string or an array in os_secrets['image']['endpoint'].
       def openstack_image_api_servers
@@ -449,7 +459,8 @@ module OSLOpenstack
 
       def safe_dig(hash, *keys)
         keys.reduce(hash) do |acc, key|
-          if acc.is_a?(Hash) || acc.is_a?(Chef::DataBagItem)
+          case acc
+          when Hash, Chef::DataBagItem, Chef::EncryptedDataBagItem
             acc[key]
           end
         end

--- a/recipes/ha.rb
+++ b/recipes/ha.rb
@@ -60,58 +60,19 @@ service 'keepalived' do
 end
 
 # HAProxy: front the OpenStack APIs on the VIP, balancing across both
-# controllers. Apache on each controller binds to its per-host listen IP
-# (see openstack_api_listen_ip), so HAProxy can bind the same ports on
-# the VIP without conflict.
+# controllers. Apache on each controller binds to its per-host listen
+# IP (see openstack_api_listen_ip), so HAProxy can bind the same ports
+# on the VIP without conflict.
 #
-# Install haproxy first so the package creates /etc/haproxy and the
-# haproxy user; then overwrite the package-default haproxy.cfg with a
-# minimal stub before the delayed service[haproxy] :start fires. The
-# package config has `bind *:5000` for a demo frontend, which would
-# hold a wildcard socket that prevents Apache from binding the per-host
-# IP on the same port even after our config replaces it (graceful
-# reload preserves listening sockets in stuck old workers).
+# On EL9 the haproxy package preset is `disabled`, so the install
+# itself doesn't start the daemon — the delayed service[haproxy]
+# :start (queued by haproxy_service[haproxy] in osl-haproxy::install)
+# is the first thing to run it, and by then the haproxy.cfg template
+# declared by haproxy_config_global below has rendered. If you ever
+# run this on a platform where the package auto-starts haproxy with
+# its demo `bind *:5000` config, stop the daemon out of band before
+# applying this recipe so it doesn't squat on a wildcard socket.
 include_recipe 'osl-haproxy::install'
-
-# If haproxy is already running (the package was just installed with
-# the demo frontend, or carrying over from a prior chef run), restart
-# it right after we overwrite haproxy.cfg with the stub. Otherwise the
-# old wildcard sockets stay bound in memory and Apache/daemons can't
-# bind their per-host IPs.
-execute 'haproxy_release_wildcards' do
-  command 'systemctl is-active haproxy >/dev/null 2>&1 && systemctl restart haproxy || true'
-  action :nothing
-end
-
-file '/etc/haproxy/haproxy.cfg' do
-  # haproxy 3.x rejects configs with no proxies, and `service[haproxy]
-  # :start` (queued by haproxy_service[haproxy] in osl-haproxy::install)
-  # fires before the real haproxy.cfg template's delayed_action :create
-  # renders. The dummy localhost listen makes this stub valid so the
-  # initial start succeeds; the proper template renders later in the
-  # delayed phase and reloads haproxy with the real listeners.
-  content <<~EOC
-    global
-        daemon
-    defaults
-        mode tcp
-        timeout connect 10s
-        timeout client 1m
-        timeout server 1m
-    listen _placeholder
-        bind 127.0.0.1:18999
-  EOC
-  mode '0644'
-  # Write the stub when the file is missing OR still holds the
-  # package-default sample frontend (which has "bind *:5000"). Skip
-  # if our Chef-managed config (which never uses bind *:) is already
-  # in place - we don't want to wipe live listeners on every run.
-  only_if do
-    !::File.exist?('/etc/haproxy/haproxy.cfg') ||
-      ::File.read('/etc/haproxy/haproxy.cfg').match?(/^\s*bind\s+\*:/)
-  end
-  notifies :run, 'execute[haproxy_release_wildcards]', :immediately
-end
 
 haproxy_config_global 'global' do
   user 'haproxy'
@@ -133,8 +94,12 @@ haproxy_config_defaults 'defaults' do
   haproxy_retries 3
 end
 
-vip4 = k['vip_v4']
-vip6 = k['vip_v6']
+# keepalived wants the VIP in CIDR form (`192.0.2.10/24`,
+# `2001:db8::10/64`) so it adds the route with the right netmask;
+# haproxy `bind` rejects CIDR and wants the bare address. Allow the
+# data bag to carry either form and strip the suffix for haproxy.
+vip4 = k['vip_v4'].to_s.split('/', 2).first
+vip6 = k['vip_v6'].to_s.split('/', 2).first if k['vip_v6']
 listen_ips = h['api_listen_ip']
 controllers = listen_ips.keys.sort
 

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -33,44 +33,50 @@ end
 if node['osl-openstack']['node_type'] == 'controller'
   package 'nagios-plugins-http'
 
+  # Hit this node's API daemons directly: on HA controllers that's the
+  # per-host private IP Apache binds to (api_listen_ip); on non-HA
+  # single-controller deploys Apache binds wildcard, so node['ipaddress']
+  # is the right target.
+  local_ip = openstack_local_api_endpoint
+
   nrpe_check 'check_keystone_api' do
     command "#{node['nrpe']['plugin_dir']}/check_http"
-    parameters "--ssl -I #{node['ipaddress']} -p 5000"
+    parameters "--ssl -I #{local_ip} -p 5000"
   end
 
   nrpe_check 'check_glance_api' do
     command "#{node['nrpe']['plugin_dir']}/check_http"
-    parameters "-I #{node['ipaddress']} -p 9292"
+    parameters "-I #{local_ip} -p 9292"
   end
 
   nrpe_check 'check_nova_api' do
     command "#{node['nrpe']['plugin_dir']}/check_http"
-    parameters "-I #{node['ipaddress']} -p 8774"
+    parameters "-I #{local_ip} -p 8774"
   end
 
   nrpe_check 'check_nova_placement_api' do
     command "#{node['nrpe']['plugin_dir']}/check_http"
-    parameters "-I #{node['ipaddress']} -p 8778"
+    parameters "-I #{local_ip} -p 8778"
   end
 
   nrpe_check 'check_novnc' do
     command "#{node['nrpe']['plugin_dir']}/check_http"
-    parameters "--ssl -I #{node['ipaddress']} -p 6080"
+    parameters "--ssl -I #{local_ip} -p 6080"
   end
 
   nrpe_check 'check_neutron_api' do
     command "#{node['nrpe']['plugin_dir']}/check_http"
-    parameters "-I #{node['ipaddress']} -p 9696"
+    parameters "-I #{local_ip} -p 9696"
   end
 
   nrpe_check 'check_cinder_api' do
     command "#{node['nrpe']['plugin_dir']}/check_http"
-    parameters "-I #{node['ipaddress']} -p 8776"
+    parameters "-I #{local_ip} -p 8776"
   end
 
   nrpe_check 'check_heat_api' do
     command "#{node['nrpe']['plugin_dir']}/check_http"
-    parameters "-I #{node['ipaddress']} -p 8004"
+    parameters "-I #{local_ip} -p 8004"
   end
 
   file '/usr/local/etc/os_cluster' do

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -1,0 +1,85 @@
+require_relative '../../spec_helper'
+require 'chef/data_bag_item'
+require 'chef/encrypted_data_bag_item'
+require_relative '../../../libraries/helpers'
+
+describe OSLOpenstack::Cookbook::Helpers do
+  # safe_dig is a private instance method on the helper module. Build a
+  # throwaway including-class so we can call it through `send`.
+  let(:helper) do
+    Class.new { include OSLOpenstack::Cookbook::Helpers }.new
+  end
+
+  def safe_dig(*args)
+    helper.send(:safe_dig, *args)
+  end
+
+  describe '#safe_dig' do
+    it 'walks a plain Hash to a leaf' do
+      expect(safe_dig({ 'a' => { 'b' => 'c' } }, 'a', 'b')).to eq('c')
+    end
+
+    it 'returns nil when a key is missing' do
+      expect(safe_dig({ 'a' => {} }, 'a', 'missing')).to be_nil
+    end
+
+    it 'returns nil when an intermediate value is not Hash-like' do
+      expect(safe_dig({ 'a' => 'leaf-string' }, 'a', 'b')).to be_nil
+    end
+
+    it 'walks a Chef::DataBagItem' do
+      item = Chef::DataBagItem.new
+      item.raw_data = { 'id' => 'x', 'ha' => { 'vip_v4' => '10.0.0.1' } }
+      expect(safe_dig(item, 'ha', 'vip_v4')).to eq('10.0.0.1')
+    end
+
+    # Regression: safe_dig used to only match Hash and Chef::DataBagItem.
+    # Chef's DSL returns Chef::EncryptedDataBagItem (a separate sibling
+    # class, NOT a DataBagItem subclass) when the bag is encrypted, so
+    # the old type check silently returned nil on encrypted bags - the
+    # `if safe_dig(os_secrets, 'ha')` gate in controller.rb stayed false
+    # in production even after the data bag was updated.
+    it 'walks a Chef::EncryptedDataBagItem' do
+      secret = 'a' * 32
+      enc_hash = {
+        'id' => 'x',
+        'ha' => Chef::EncryptedDataBagItem::Encryptor.new(
+          { 'vip_v4' => '10.0.0.1' },
+          secret
+        ).for_encrypted_item,
+      }
+      item = Chef::EncryptedDataBagItem.new(enc_hash, secret)
+      expect(safe_dig(item, 'ha', 'vip_v4')).to eq('10.0.0.1')
+    end
+  end
+
+  describe '#openstack_local_api_endpoint' do
+    let(:fqdn) { 'controller1.testing.osuosl.org' }
+
+    before do
+      allow(helper).to receive(:node).and_return(
+        'fqdn' => fqdn,
+        'ipaddress' => '10.0.0.2'
+      )
+    end
+
+    it 'returns the per-host api_listen_ip when HA is configured' do
+      allow(helper).to receive(:os_secrets).and_return(
+        'ha' => { 'api_listen_ip' => { fqdn => '10.1.2.3' } }
+      )
+      expect(helper.openstack_local_api_endpoint).to eq('10.1.2.3')
+    end
+
+    it "falls back to node['ipaddress'] when HA isn't configured" do
+      allow(helper).to receive(:os_secrets).and_return({})
+      expect(helper.openstack_local_api_endpoint).to eq('10.0.0.2')
+    end
+
+    it "falls back to node['ipaddress'] when this node has no api_listen_ip entry" do
+      allow(helper).to receive(:os_secrets).and_return(
+        'ha' => { 'api_listen_ip' => { 'other.fqdn' => '10.1.2.99' } }
+      )
+      expect(helper.openstack_local_api_endpoint).to eq('10.0.0.2')
+    end
+  end
+end

--- a/spec/unit/recipes/ha_spec.rb
+++ b/spec/unit/recipes/ha_spec.rb
@@ -16,8 +16,10 @@ describe 'osl-openstack::ha' do
               'priority' => { 'fauxhai.local' => 100 },
               'virtual_router_id' => 1,
               'auth_pass' => 'auth_pass',
-              'vip_v4' => '192.168.60.10',
-              'vip_v6' => 'fc00::10',
+              # CIDR notation - keepalived gets the full string,
+              # haproxy bind directives must use the stripped form.
+              'vip_v4' => '192.168.60.10/24',
+              'vip_v6' => 'fc00::10/64',
             },
             'api_listen_ip' => {
               'fauxhai.local' => '192.168.60.11',
@@ -32,6 +34,38 @@ describe 'osl-openstack::ha' do
 
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
+      end
+
+      it 'passes the VIP to keepalived in CIDR form' do
+        expect(chef_run).to create_keepalived_vrrp_instance('openstack-ipv4').with(
+          virtual_ipaddress: ['192.168.60.10/24']
+        )
+        expect(chef_run).to create_keepalived_vrrp_instance('openstack-ipv6').with(
+          virtual_ipaddress: ['fc00::10/64']
+        )
+      end
+
+      it 'strips the CIDR before passing the VIPs to haproxy bind' do
+        # keystone is representative; every haproxy_listen in the
+        # openstack_ha_services loop builds its v4 + v6 binds the same
+        # way. Without the strip we'd see '192.168.60.10/24:5000' or
+        # '[fc00::10/64]:5000'.
+        binds = chef_run.find_resources(:haproxy_listen)
+                        .select { |r| r.name == 'keystone' }
+                        .map(&:bind)
+        expect(binds).to contain_exactly(
+          '192.168.60.10:5000',
+          '[fc00::10]:5000'
+        )
+      end
+
+      it 'does not write the stub haproxy.cfg or the wildcard-release execute' do
+        # Removed in favor of letting the haproxy.cfg template's
+        # delayed_action :create handle initial rendering. EL9's
+        # haproxy package preset is `disabled`, so the package install
+        # doesn't auto-start the daemon with bind *:5000.
+        expect(chef_run.find_resources(:file).map(&:name)).not_to include('/etc/haproxy/haproxy.cfg')
+        expect(chef_run.find_resources(:execute).map(&:name)).not_to include('haproxy_release_wildcards')
       end
     end
   end

--- a/spec/unit/recipes/mon_spec.rb
+++ b/spec/unit/recipes/mon_spec.rb
@@ -94,6 +94,43 @@ describe 'osl-openstack::mon' do
           )
         end
       end
+      context 'HA controller' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm) do |node|
+            node.normal['osl-openstack']['node_type'] = 'controller'
+            node.automatic['fqdn'] = 'controller1.testing.osuosl.org'
+          end.converge(described_recipe)
+        end
+
+        before do
+          stub_data_bag_item('openstack', 'x86').and_return(
+            'database_server' => { 'suffix' => 'x86' },
+            'ha' => {
+              'api_listen_ip' => {
+                'controller1.testing.osuosl.org' => '10.1.2.3',
+              },
+            }
+          )
+        end
+
+        # Each nrpe_check should target the per-host backend IP from
+        # ha.api_listen_ip, not node['ipaddress'].
+        {
+          'check_keystone_api' => '--ssl -I 10.1.2.3 -p 5000',
+          'check_glance_api' => '-I 10.1.2.3 -p 9292',
+          'check_nova_api' => '-I 10.1.2.3 -p 8774',
+          'check_nova_placement_api' => '-I 10.1.2.3 -p 8778',
+          'check_novnc' => '--ssl -I 10.1.2.3 -p 6080',
+          'check_neutron_api' => '-I 10.1.2.3 -p 9696',
+          'check_cinder_api' => '-I 10.1.2.3 -p 8776',
+          'check_heat_api' => '-I 10.1.2.3 -p 8004',
+        }.each do |name, params|
+          it "passes the api_listen_ip to #{name}" do
+            expect(chef_run).to add_nrpe_check(name).with(parameters: params)
+          end
+        end
+      end
+
       context 'ppc64le' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(pltfrm) do |node|

--- a/test/integration/data_bags/openstack/ha.json
+++ b/test/integration/data_bags/openstack/ha.json
@@ -13,8 +13,8 @@
       },
       "virtual_router_id": 1,
       "auth_pass": "auth_pass",
-      "vip_v4": "192.168.60.10",
-      "vip_v6": "fc00::10"
+      "vip_v4": "192.168.60.10/24",
+      "vip_v6": "fc00::10/64"
     },
     "api_listen_ip": {
       "controller.testing.osuosl.org": "192.168.60.11"

--- a/test/integration/data_bags/openstack/multinode.json
+++ b/test/integration/data_bags/openstack/multinode.json
@@ -110,8 +110,8 @@
       },
       "virtual_router_id": 51,
       "auth_pass": "vrrp_pass",
-      "vip_v4": "10.1.2.10",
-      "vip_v6": "fd00:1:2::10"
+      "vip_v4": "10.1.2.10/23",
+      "vip_v6": "fd00:1:2::10/64"
     },
     "api_listen_ip": {
       "controller.novalocal": "10.1.2.3",

--- a/test/integration/ha/controls/ha.rb
+++ b/test/integration/ha/controls/ha.rb
@@ -20,11 +20,13 @@ end
 
 control 'vip-bound' do
   # Single-node test: this node is master and should hold the VIPs.
+  # CIDR matches the data bag (vip_v4: 192.168.60.10/24, vip_v6:
+  # fc00::10/64) - keepalived honors the supplied prefix length.
   describe command('ip -4 addr show dev eth1') do
-    its('stdout') { should match(%r{192\.168\.60\.10/32}) }
+    its('stdout') { should match(%r{192\.168\.60\.10/24}) }
   end
   describe command('ip -6 addr show dev eth1') do
-    its('stdout') { should match(%r{fc00::10/128}) }
+    its('stdout') { should match(%r{fc00::10/64}) }
   end
 end
 

--- a/test/integration/ha_master/controls/ha_master.rb
+++ b/test/integration/ha_master/controls/ha_master.rb
@@ -27,11 +27,13 @@ end
 
 control 'vip-held' do
   title 'Master holds the VIP'
+  # CIDR matches the multinode data bag (vip_v4: 10.1.2.10/23,
+  # vip_v6: fd00:1:2::10/64).
   describe command("ip -4 addr show dev #{vrrp_iface}") do
-    its('stdout') { should match(%r{#{Regexp.escape(vip_v4)}/32}) }
+    its('stdout') { should match(%r{#{Regexp.escape(vip_v4)}/23}) }
   end
   describe command("ip -6 addr show dev #{vrrp_iface}") do
-    its('stdout') { should match(%r{#{Regexp.escape(vip_v6)}/128}) }
+    its('stdout') { should match(%r{#{Regexp.escape(vip_v6)}/64}) }
   end
 end
 

--- a/test/integration/ha_standby/controls/ha_standby.rb
+++ b/test/integration/ha_standby/controls/ha_standby.rb
@@ -27,11 +27,13 @@ end
 
 control 'vip-not-held' do
   title 'Standby does not hold the VIP'
+  # Whatever CIDR the master ends up with (10.1.2.10/23 from the
+  # multinode data bag), it must NOT be present on the standby.
   describe command("ip -4 addr show dev #{vrrp_iface}") do
-    its('stdout') { should_not match(%r{#{Regexp.escape(vip_v4)}/32}) }
+    its('stdout') { should_not match(/#{Regexp.escape(vip_v4)}\b/) }
   end
   describe command("ip -6 addr show dev #{vrrp_iface}") do
-    its('stdout') { should_not match(%r{#{Regexp.escape(vip_v6)}/128}) }
+    its('stdout') { should_not match(/#{Regexp.escape(vip_v6)}\b/) }
   end
 end
 


### PR DESCRIPTION
Four production-discovered fixes for the active-active HA controller
path, plus matching test updates.

* safe_dig now matches Chef::EncryptedDataBagItem. The DSL returns
  that class (a separate sibling, NOT a Chef::DataBagItem subclass)
  when the bag is encrypted, so the old type check silently returned
  nil and the `if safe_dig(os_secrets, 'ha')` gate in controller.rb
  never fired in production even after the data bag was updated.
  Adds spec/unit/libraries/helpers_spec.rb covering Hash,
  DataBagItem, EncryptedDataBagItem, and the missing-key paths.

* ha.vip_v4 / vip_v6 in the data bag now accept CIDR notation
  (e.g. 192.0.2.10/24, 2001:db8::10/64). keepalived gets the full
  string so it adds the address with the right prefix length;
  haproxy `bind` rejects CIDR, so we strip the suffix before
  building the bind directives. ha.json and multinode.json data bags
  switched to CIDR; ha / ha_master / ha_standby InSpec controls now
  expect /24 (and /23 for multinode) and /64 instead of the
  keepalived default /32 / /128.

* Removed the stub haproxy.cfg file resource + the
  haproxy_release_wildcards execute. On EL9 the haproxy package
  preset is `disabled`, so the install doesn't auto-start the daemon
  with bind *:5000 - the delayed service[haproxy] :start +
  template :create chain in osl-haproxy::install handles initial
  rendering on its own. The only_if regex (`/^\s*bind\s+\*:/`) was
  also fragile: any future legitimate `bind *:<port>` line would
  match and have the stub silently overwrite the real config.

* The eight NRPE check_http probes in mon.rb hit node['ipaddress'].
  In HA mode Apache no longer binds the wildcard - it binds the
  per-host private IP (ha.api_listen_ip), so the local probes either
  land on HAProxy on the VIP or fail entirely. Adds
  openstack_local_api_endpoint helper that returns
  ha.api_listen_ip[node['fqdn']] when HA is configured and falls
  back to node['ipaddress'] otherwise (no behavior change for
  single-controller deploys).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
