### PR TITLE
network_controller: skip qdhcp iptables when the namespace is absent

### DIFF
--- a/recipes/network_controller.rb
+++ b/recipes/network_controller.rb
@@ -121,13 +121,19 @@ end
 
 n['physical_interface_mappings'].each do |network|
   next if network['subnet'].nil? || network['uuid'].nil?
-  ip_cmd = "ip netns exec qdhcp-#{network['uuid']}"
+  netns = "qdhcp-#{network['uuid']}"
+  ip_cmd = "ip netns exec #{netns}"
 
   bash "block external dns on #{network['name']}" do
     code <<~EOL
       #{ip_cmd} iptables -A INPUT -p tcp --dport 53 ! -s #{network['subnet']} -j DROP
       #{ip_cmd} iptables -A INPUT -p udp --dport 53 ! -s #{network['subnet']} -j DROP
     EOL
+    # In HA mode the DHCP scheduler may not have placed this network on
+    # this controller's neutron-dhcp-agent yet, so the qdhcp namespace
+    # won't exist locally. Skip rather than fail; the next chef run
+    # after the scheduler assigns the network will apply the rule.
+    only_if { ::File.exist?("/run/netns/#{netns}") }
     not_if "#{ip_cmd} iptables -S | egrep \"#{network['subnet']}.*port 53.*DROP\""
   end
 end

--- a/spec/unit/recipes/network_controller_spec.rb
+++ b/spec/unit/recipes/network_controller_spec.rb
@@ -12,6 +12,18 @@ describe 'osl-openstack::network_controller' do
       include_context 'common_stubs'
       include_context 'network_stubs'
 
+      before do
+        # The iptables-in-namespace bash is guarded by an only_if on
+        # File.exist?('/run/netns/<qdhcp ns>'). The default-context
+        # cached(:chef_run) asserts the bash runs, so stub the
+        # namespace path to exist. The "namespace missing" branch is
+        # exercised in its own context below.
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?)
+          .with('/run/netns/qdhcp-8df74e06-c4aa-4eb2-b312-0e915bf8f97f')
+          .and_return(true)
+      end
+
       it { is_expected.to add_osl_repos_openstack 'network' }
       it { is_expected.to create_osl_openstack_client 'network' }
       it { is_expected.to accept_osl_firewall_openstack 'network' }
@@ -165,6 +177,26 @@ describe 'osl-openstack::network_controller' do
         )
       end
       it { is_expected.to_not run_bash 'block external dns on private1' }
+
+      context 'when the qdhcp namespace is not present on this controller' do
+        # Simulates an HA secondary where the neutron-dhcp scheduler
+        # hasn't placed the network on this node's dhcp-agent yet, so
+        # /run/netns/qdhcp-<uuid> doesn't exist locally.
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm) do |node|
+            node.normal['osl-openstack']['node_type'] = 'controller'
+          end.converge(described_recipe)
+        end
+
+        before do
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?)
+            .with('/run/netns/qdhcp-8df74e06-c4aa-4eb2-b312-0e915bf8f97f')
+            .and_return(false)
+        end
+
+        it { is_expected.to_not run_bash 'block external dns on public' }
+      end
 
       context 'fqdn controller' do
         cached(:chef_run) do


### PR DESCRIPTION
The "block external dns on <network>" bash unconditionally shells out
to `ip netns exec qdhcp-<uuid> iptables ...`. On an HA secondary the
neutron-dhcp scheduler may not have placed the network on this node's
dhcp-agent yet, so /run/netns/qdhcp-<uuid> doesn't exist locally and
the bash fails with exit 255 (`Cannot open network namespace`). The
existing not_if's `ip netns exec` would have caught it as a skip
signal, but it returns the same non-zero exit, which Chef reads as
"guard not satisfied, run the resource".

Add an only_if that checks the namespace's procfs file directly. When
the namespace is missing the resource is skipped cleanly; the next
chef run after the scheduler assigns the network applies the rule.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
