### PR TITLE
ha: tell osl-apache it is behind a load balancer

### DIFF
--- a/recipes/ha.rb
+++ b/recipes/ha.rb
@@ -22,6 +22,14 @@ s = os_secrets
 h = s['ha']
 k = h['keepalived']
 
+# Apache sits behind HAProxy on the VIP, so every request arrives
+# from haproxy's source IP. Tell osl-apache to honor X-Forwarded-For
+# / X-Forwarded-Proto from haproxy so REMOTE_ADDR + the WSGI/PHP
+# scheme reflect the real client instead of the load balancer.
+# Set this before any recipe pulls in osl-apache - controller.rb
+# includes ha first, so identity/dashboard/etc see this attribute.
+node.default['osl-apache']['behind_loadbalancer'] = true
+
 # Allow HAProxy on the standby controller to bind to the VIP it doesn't
 # currently hold; on failover the bind takes effect immediately.
 %w(net.ipv4.ip_nonlocal_bind net.ipv6.ip_nonlocal_bind).each do |key|

--- a/spec/unit/recipes/ha_spec.rb
+++ b/spec/unit/recipes/ha_spec.rb
@@ -36,6 +36,12 @@ describe 'osl-openstack::ha' do
         expect { chef_run }.to_not raise_error
       end
 
+      it 'tells osl-apache it is behind a load balancer' do
+        # So Apache trusts X-Forwarded-For / X-Forwarded-Proto from
+        # haproxy and REMOTE_ADDR reflects the real client.
+        expect(chef_run.node['osl-apache']['behind_loadbalancer']).to be true
+      end
+
       it 'passes the VIP to keepalived in CIDR form' do
         expect(chef_run).to create_keepalived_vrrp_instance('openstack-ipv4').with(
           virtual_ipaddress: ['192.168.60.10/24']


### PR DESCRIPTION
Apache now sits behind HAProxy on the VIP, so every request arrives
from haproxy's source IP and REMOTE_ADDR is the haproxy backend
address. Set node['osl-apache']['behind_loadbalancer'] = true in the
ha recipe so osl-apache wires up the X-Forwarded-For /
X-Forwarded-Proto trust knobs and Apache logs (and any WSGI/PHP code
that reads REMOTE_ADDR) see the real client IP again.

controller.rb includes osl-openstack::ha before identity / dashboard
/ etc., so the attribute is set before any recipe pulls osl-apache
in.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
