### PR TITLE
ha: stop the keystone canonical-host redirect and move horizon http->https to haproxy

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -284,12 +284,15 @@ module OSLOpenstack
       end
 
       # OpenStack APIs to put behind HAProxy on the controller VIP.
-      # Horizon (80/443) uses 'source' for session affinity; everything
-      # else round-robins. The openstack_exporter (port 9183) is
-      # intentionally NOT fronted - its package only supports listen_port
-      # (no listen_address), so it always binds 0.0.0.0 which would
-      # conflict with a VIP bind on the same host. Prometheus should
-      # scrape both controllers directly as separate targets.
+      # horizon-https uses 'source' for session affinity; horizon-http
+      # is a redirect-only listener that 301s to https (the rewrite
+      # that used to live in the Apache horizon vhost moves to haproxy
+      # in HA mode). Everything else round-robins. The
+      # openstack_exporter (port 9183) is intentionally NOT fronted -
+      # its package only supports listen_port (no listen_address), so
+      # it always binds 0.0.0.0 which would conflict with a VIP bind
+      # on the same host. Prometheus should scrape both controllers
+      # directly as separate targets.
       #
       # `tls: true` marks services that already serve TLS today
       # (keystone + horizon-https via Apache vhost SSL, novnc via
@@ -311,7 +314,7 @@ module OSLOpenstack
           { name: 'heat-api',       port: 8004 },
           { name: 'heat-cfn',       port: 8000 },
           { name: 'novnc',          port: 6080, tls: true },
-          { name: 'horizon-http',   port: 80,  balance: 'source' },
+          { name: 'horizon-http',   port: 80,  redirect_to_https: true },
           { name: 'horizon-https',  port: 443, balance: 'source', tls: true },
         ]
       end

--- a/recipes/ha.rb
+++ b/recipes/ha.rb
@@ -190,18 +190,28 @@ openstack_ha_services.each do |svc|
 
   haproxy_listen svc[:name] do
     bind "#{vip4}:#{port}#{cert_opt}"
-    mode svc[:tls] ? 'http' : 'tcp'
-    option ['forwardfor'] if svc[:tls]
-    # Tell the backend the request was originally HTTPS so Django /
-    # oslo middleware build correct redirect URLs and set the
-    # secure-cookie flag. `ssl_fc` is true on the TLS-terminated
-    # frontend connection.
-    http_request [
-      'set-header X-Forwarded-Proto https if { ssl_fc }',
-      'set-header X-Forwarded-Proto http if !{ ssl_fc }',
-    ] if svc[:tls]
-    extra_options('balance' => svc[:balance] || 'roundrobin')
-    server servers
+    if svc[:redirect_to_https]
+      # Plain-HTTP listener whose only job is to 301 to https. Apache
+      # used to do this in its wsgi-horizon :80 vhost; that rewrite is
+      # gated off in HA mode (Apache backends serve plain HTTP behind
+      # haproxy and would loop on %{HTTPS}=off), so haproxy owns it.
+      # No backend servers - every request terminates here.
+      mode 'http'
+      http_request ['redirect scheme https code 301']
+    else
+      mode svc[:tls] ? 'http' : 'tcp'
+      option ['forwardfor'] if svc[:tls]
+      # Tell the backend the request was originally HTTPS so Django /
+      # oslo middleware build correct redirect URLs and set the
+      # secure-cookie flag. `ssl_fc` is true on the TLS-terminated
+      # frontend connection.
+      http_request [
+        'set-header X-Forwarded-Proto https if { ssl_fc }',
+        'set-header X-Forwarded-Proto http if !{ ssl_fc }',
+      ] if svc[:tls]
+      extra_options('balance' => svc[:balance] || 'roundrobin')
+      server servers
+    end
   end
 
   haproxy_listen svc[:name] do

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -174,5 +174,15 @@ describe OSLOpenstack::Cookbook::Helpers do
         'horizon-http'
       )
     end
+
+    it 'tags horizon-http as a redirect-only listener' do
+      horizon_http = services.find { |s| s[:name] == 'horizon-http' }
+      expect(horizon_http[:redirect_to_https]).to be true
+    end
+
+    it 'does not tag any tls listener as redirect_to_https' do
+      tls_redirects = services.select { |s| s[:tls] && s[:redirect_to_https] }
+      expect(tls_redirects).to be_empty
+    end
   end
 end

--- a/spec/unit/recipes/ha_spec.rb
+++ b/spec/unit/recipes/ha_spec.rb
@@ -90,6 +90,19 @@ describe 'osl-openstack::ha' do
         expect(glance_first.option).to be_nil # property unset
       end
 
+      it 'makes horizon-http a 301 redirect to https with no backend' do
+        # Apache's wsgi-horizon :80 vhost used to do the http->https
+        # rewrite; in HA that rewrite is gated off (Apache backends
+        # serve plain HTTP behind haproxy and would loop on %{HTTPS}=off).
+        # haproxy owns the redirect now: mode http, the redirect rule,
+        # no backend servers since every request terminates here.
+        horizon_http = chef_run.find_resources(:haproxy_listen)
+                               .find { |r| r.name == 'horizon-http' }
+        expect(horizon_http.mode).to eq('http')
+        expect(horizon_http.http_request).to include('redirect scheme https code 301')
+        expect(horizon_http.server).to be_nil
+      end
+
       it 'builds the haproxy wildcard PEM bundle' do
         expect(chef_run).to create_directory('/etc/haproxy/certs').with(
           owner: 'haproxy', group: 'haproxy', mode: '0700'

--- a/templates/wsgi-keystone.conf.erb
+++ b/templates/wsgi-keystone.conf.erb
@@ -7,12 +7,12 @@ WSGISocketPrefix /var/lock/subsys
   ServerAlias <%= @server_aliases.flatten.join(" ") %>
   <% end %>
 
+<% unless @template_params && @template_params[:haproxy_tls] -%>
   RewriteEngine On
   RewriteCond "%{HTTP_HOST}" "!^<%= Regexp.escape(@server_name) %>" [NC]
   RewriteCond "%{HTTP_HOST}" "!^$"
   RewriteRule "^/?(.*)"      "https://<%= @server_name %>:5000/$1" [L,R=permanent,NE]
 
-<% unless @template_params && @template_params[:haproxy_tls] -%>
   SSLEngine On
   SSLCertificateFile /etc/pki/tls/certs/wildcard.pem
   SSLCertificateKeyFile /etc/pki/tls/private/wildcard.key

--- a/test/integration/ha_master/controls/ha_master.rb
+++ b/test/integration/ha_master/controls/ha_master.rb
@@ -64,6 +64,10 @@ control 'haproxy-tls-termination' do
     # plain-HTTP backends have no ssl crt
     its('content') { should match(/bind #{Regexp.escape(vip_v4)}:9292$/) }
     its('content') { should match(/bind #{Regexp.escape(vip_v4)}:9696$/) }
+    # horizon-http (:80) is a redirect-only listener that 301s to https,
+    # replacing Apache's wsgi-horizon http->https rewrite which is gated
+    # off in HA mode.
+    its('content') { should match(/^\s*http-request redirect scheme https code 301/) }
   end
 
   # Probe by canonical hostname (resolves to the VIP via /etc/hosts) so


### PR DESCRIPTION
Fix a 400 from chef -> keystone on the freshly-cut-over HA cluster:

  Excon::Error::BadRequest at osl-openstack::identity:140
  GET https://<controller>:5000/v3/roles -> 400
  body: "You're speaking plain HTTP to an SSL-enabled server port."

haproxy terminates TLS on the VIP and forwards plain HTTP to the Apache
backend on :5000. The keystone vhost's canonical-host rewrite was firing
on requests whose Host header didn't match (haproxy healthchecks,
internal traffic, X-Forwarded-* edge cases), redirecting clients into a
path that surfaces backend-side TLS/plain-HTTP mismatches. With
SSLEngine already gated off in HA the rewrite has no useful role; in
non-HA single-controller Apache still terminates TLS and the rewrite
is still wanted, so gate it the same way as the SSL block.

Apache's wsgi-horizon :80 vhost also did an unconditional http->https
rewrite that would loop on Apache when %{HTTPS} is always off behind
haproxy. With that rewrite gated off, haproxy needs to own the
redirect.

- wsgi-keystone.conf.erb: move the RewriteEngine/Cond/Rule block inside
  the existing `unless @template_params && @template_params[:haproxy_tls]`
  gate, alongside the SSL config. Non-HA behavior unchanged.

- helpers.rb: tag horizon-http with `redirect_to_https: true`; drop
  `balance: 'source'` from it (no backend to balance to).

- ha.rb: in the haproxy_listen loop, when a service has
  `redirect_to_https`, emit `mode http` + `http-request redirect scheme
  https code 301` with no backend servers - every request terminates
  with the 301. Everything else keeps the existing tls/forwardfor /
  plain-tcp paths.

- Tests: helpers_spec asserts horizon-http carries the flag and no TLS
  service does; ha_spec asserts the listener is mode http with the
  redirect rule and no server; ha_master InSpec asserts haproxy.cfg
  contains `http-request redirect scheme https code 301`.

Note on identity: keystone is TLS-only on :5000, with no plain-HTTP
listener for haproxy to attach a redirect to. The production 400 above
was the Apache redirect feeding clients into a broken path, not a
missing http->https; gating that redirect (this commit) is the fix.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
