### PR TITLE
identity: open memcached to OSL CIDRs so horizon sessions survive failover

### DIFF
--- a/recipes/dashboard.rb
+++ b/recipes/dashboard.rb
@@ -25,7 +25,6 @@ osl_openstack_openrc 'dashboard'
 listen_ip = openstack_api_listen_ip
 node.default['osl-apache']['listen'] = %w(80 443).map { |p| "#{listen_ip}:#{p}" }
 
-include_recipe 'osl-memcached'
 include_recipe 'osl-apache'
 include_recipe 'osl-apache::mod_wsgi'
 include_recipe 'osl-apache::mod_ssl'

--- a/recipes/identity.rb
+++ b/recipes/identity.rb
@@ -24,7 +24,20 @@ osl_openstack_openrc 'identity'
 listen_ip = openstack_api_listen_ip
 node.default['osl-apache']['listen'] = %w(80 443).map { |p| "#{listen_ip}:#{p}" }
 
+# Declare memcached ourselves so we can open the firewall to all
+# OSL-managed nodes (peer controllers for horizon sessions, compute
+# nodes for keystone_authtoken caching). Default localhost-only would
+# shard horizon sessions per-controller and force a re-login on every
+# VIP failover, and leaves nova-compute silently falling back to
+# direct keystone validation. Mirrors AMQP's `osl_only: true`.
+node.default['osl-memcached']['default_service'] = false
 include_recipe 'osl-memcached'
+
+osl_memcached 'memcached' do
+  port 11211
+  osl_only true
+end
+
 include_recipe 'osl-apache'
 include_recipe 'osl-apache::mod_wsgi'
 include_recipe 'osl-apache::mod_ssl'

--- a/spec/unit/recipes/dashboard_spec.rb
+++ b/spec/unit/recipes/dashboard_spec.rb
@@ -15,13 +15,14 @@ describe 'osl-openstack::dashboard' do
       it { is_expected.to create_osl_openstack_client 'dashboard' }
       it { is_expected.to accept_osl_firewall_openstack 'dashboard' }
       %w(
-        osl-memcached
         osl-apache
         osl-apache::mod_wsgi
         osl-apache::mod_ssl
       ).each do |r|
         it { is_expected.to include_recipe r }
       end
+      # memcached setup lives in ::identity (runs first via controller.rb).
+      it { is_expected.to_not include_recipe 'osl-memcached' }
       it { is_expected.to install_package 'openstack-dashboard' }
       it do
         is_expected.to create_certificate_manage('wildcard-dashboard').with(

--- a/spec/unit/recipes/identity_spec.rb
+++ b/spec/unit/recipes/identity_spec.rb
@@ -138,6 +138,16 @@ describe 'osl-openstack::identity' do
       it { expect(chef_run.apache_app('keystone')).to notify('apache2_service[osuosl]').to(:reload) }
       it { is_expected.to create_osl_openstack_role 'service' }
       it { is_expected.to create_osl_openstack_project('service').with(domain_name: 'default') }
+
+      # osl_only opens :11211 to all OSL CIDRs (controllers + computes);
+      # iptables rule asserted live in identity InSpec.
+      it { expect(chef_run.node['osl-memcached']['default_service']).to be false }
+      it do
+        is_expected.to create_osl_memcached('memcached').with(
+          port: 11211,
+          osl_only: true
+        )
+      end
     end
   end
 end

--- a/test/integration/ha_master/controls/ha_master.rb
+++ b/test/integration/ha_master/controls/ha_master.rb
@@ -77,3 +77,12 @@ control 'haproxy-tls-termination' do
     its('status') { should cmp 200 }
   end
 end
+
+control 'memcached-cross-controller' do
+  title 'memcached firewall lets the peer controller in (horizon sessions survive failover)'
+  # osl_only sends the rule into the OSL CIDR chain - covers peer
+  # controllers and compute nodes in one knob (mirrors AMQP).
+  describe iptables do
+    it { should have_rule('-A memcached -p tcp -m tcp --dport 11211 -j osl_only') }
+  end
+end

--- a/test/integration/ha_standby/controls/ha_standby.rb
+++ b/test/integration/ha_standby/controls/ha_standby.rb
@@ -61,3 +61,12 @@ control 'haproxy-tls-termination' do
     its('content') { should match(/option forwardfor/) }
   end
 end
+
+control 'memcached-cross-controller' do
+  title 'memcached firewall lets the peer controller in (horizon sessions survive failover)'
+  # Symmetric with ha_master: identity.rb runs on both controllers and
+  # configures memcached the same way.
+  describe iptables do
+    it { should have_rule('-A memcached -p tcp -m tcp --dport 11211 -j osl_only') }
+  end
+end

--- a/test/integration/identity/controls/identity_spec.rb
+++ b/test/integration/identity/controls/identity_spec.rb
@@ -24,6 +24,32 @@ control 'openstack-identity' do
     it { should be_running }
   end
 
+  describe port(11211) do
+    it { should be_listening }
+    its('processes') { should include 'memcached' }
+    its('protocols') { should include 'tcp' }
+    its('protocols') { should include 'udp' }
+  end
+
+  # osl_memcached uses `osl_only: true`: the memcached chain jumps to
+  # the OSL CIDR chain (no -s rule). Local nc still works because
+  # osl-firewall accepts all lo traffic via the 20_loopback chain.
+  describe iptables do
+    it { should have_rule('-A memcached -p tcp -m tcp --dport 11211 -j osl_only') }
+    it { should have_rule('-A memcached -p udp -m udp --dport 11211 -j osl_only') }
+  end
+
+  describe ip6tables do
+    it { should have_rule('-A memcached -p tcp -m tcp --dport 11211 -j osl_only') }
+    it { should have_rule('-A memcached -p udp -m udp --dport 11211 -j osl_only') }
+  end
+
+  # Prometheus exporter scrapes localhost:11211 and reports up=1.
+  describe http('http://localhost:9150/metrics') do
+    its('status') { should cmp 200 }
+    its('body') { should match(/memcached_up 1/) }
+  end
+
   describe port(5000) do
     it { should be_listening }
     its('protocols') { should include 'tcp' }
@@ -38,13 +64,20 @@ control 'openstack-identity' do
     its(%w(version status)) { should cmp 'stable' }
   end
 
-  describe http(
-    'https://controller.testing.osuosl.org:5000',
-    headers: { 'Host' => 'controller1.testing.osuosl.org' },
-    ssl_verify: false
-  ) do
-    its('status') { should cmp 301 }
-    its('headers.location') { should cmp 'https://controller.testing.osuosl.org:5000/' }
+  # The wsgi-keystone canonical-host rewrite (Host !~ server_name ->
+  # 301 to https://server_name:5000/) is gated off when haproxy
+  # terminates TLS: behind the VIP the rewrite would 301 healthchecks
+  # and internal traffic into a loop. In HA, keystone itself answers
+  # with its 300 version-discovery payload instead.
+  unless input('haproxy_tls', value: false)
+    describe http(
+      'https://controller.testing.osuosl.org:5000',
+      headers: { 'Host' => 'controller1.testing.osuosl.org' },
+      ssl_verify: false
+    ) do
+      its('status') { should cmp 301 }
+      its('headers.location') { should cmp 'https://controller.testing.osuosl.org:5000/' }
+    end
   end
 
   describe port(11211) do


### PR DESCRIPTION
osl-memcached's default firewall locks `:11211` to `127.0.0.1`, so in
HA each horizon ends up using only its local memcached (python-memcached
marks the peer dead on connection-refused) — sessions shard per-node
and every VIP failover forces a re-login. Compute nodes have the same
problem on a slower path: nova-compute's keystone_authtoken is
configured for memcached but can't reach it, silently falling back to
validating tokens against keystone directly on every call.

Declare memcached via `osl_memcached` directly with `osl_only: true`,
mirroring how AMQP is opened via `osl_firewall_port 'amqp' do
osl_only true end`. Opens `:11211` to all OSL-managed CIDRs in one
knob — controllers, computes, anything OSL. Local Apache → local
memcached keeps working via osl-firewall's `20_loopback` chain.

- `identity.rb`: flip `default_service` off, declare `osl_memcached
  'memcached' do port 11211; osl_only true end`. Resource named
  `'memcached'` so the systemd unit stays `memcached.service`
  (sous-chefs renames any other instance to `memcached_<name>.service`).
- `dashboard.rb`: drop the redundant `include_recipe 'osl-memcached'`
  (identity runs first via controller.rb).
- identity InSpec: assert :11211 is listening, `nc localhost 11211`
  returns stats, both iptables and ip6tables have the
  `-j osl_only` rule, and the prometheus exporter reports `up=1`.
- ha_master / ha_standby InSpec: assert the `-j osl_only` jump
  (symmetric — both controllers configure memcached the same way).
- ChefSpec: identity asserts `default_service: false` and
  `osl_only: true`; dashboard locks in the include removal.

Pairs with osl-memcached's "Gate osl_firewall_memcached on
default_service" + "Add osl_only property to osl_memcached"; bump the
metadata.rb pin once that's released.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
