### PR TITLE
mon: drop --ssl on keystone and novnc nrpe checks under HA

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -33,6 +33,7 @@ suites:
     run_list:
       - recipe[openstack_test::ha]
       - recipe[osl-openstack::ha]
+      - recipe[osl-openstack::mon]
   - name: ops_messaging
     driver_config:
       server_name: "ops-messaging-<%= ENV['USER'] %>"

--- a/main.tf
+++ b/main.tf
@@ -347,7 +347,7 @@ resource "null_resource" "controller1" {
             knife bootstrap -c test/chef-config/knife.rb \
                 ${var.ssh_user_name}@${openstack_compute_instance_v2.controller1.network.0.fixed_ip_v4} \
                 --bootstrap-version ${var.chef_version} -y -N controller1 --sudo \
-                -r 'role[openstack_tf_common],role[openstack_controller],recipe[openstack_test::prometheus],recipe[osl-openstack::ops_messaging],recipe[osl-openstack::controller],recipe[osl-openstack::block_storage],recipe[openstack_test::image_upload],recipe[openstack_test::create_network]'
+                -r 'role[openstack_tf_common],role[openstack_controller],recipe[openstack_test::prometheus],recipe[osl-openstack::ops_messaging],recipe[osl-openstack::controller],recipe[osl-openstack::block_storage],recipe[osl-openstack::mon],recipe[openstack_test::image_upload],recipe[openstack_test::create_network]'
             EOF
         environment = {
             CHEF_SERVER = "${openstack_compute_instance_v2.chef_zero.network.0.fixed_ip_v4}"
@@ -385,7 +385,7 @@ resource "null_resource" "controller2" {
             knife bootstrap -c test/chef-config/knife.rb \
                 ${var.ssh_user_name}@${openstack_compute_instance_v2.controller2.network.0.fixed_ip_v4} \
                 --bootstrap-version ${var.chef_version} -y -N controller2 --sudo \
-                -r 'role[openstack_tf_common],role[openstack_controller],recipe[osl-openstack::ops_messaging],recipe[osl-openstack::controller],recipe[osl-openstack::block_storage]'
+                -r 'role[openstack_tf_common],role[openstack_controller],recipe[osl-openstack::ops_messaging],recipe[osl-openstack::controller],recipe[osl-openstack::block_storage],recipe[osl-openstack::mon]'
             EOF
         environment = {
             CHEF_SERVER = "${openstack_compute_instance_v2.chef_zero.network.0.fixed_ip_v4}"

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -39,9 +39,17 @@ if node['osl-openstack']['node_type'] == 'controller'
   # is the right target.
   local_ip = openstack_local_api_endpoint
 
+  # keystone and novnc are the two backends that terminate TLS
+  # themselves on non-HA single-controller (Apache mod_ssl /
+  # nova-novncproxy --ssl_only); in HA mode they serve plain HTTP /
+  # plain ws on the per-host IP and haproxy on the VIP is the TLS
+  # endpoint. The local nrpe check has to match what the backend
+  # actually speaks, so drop --ssl when haproxy_tls is on.
+  backend_ssl_opt = openstack_tls_on_haproxy? ? '' : '--ssl '
+
   nrpe_check 'check_keystone_api' do
     command "#{node['nrpe']['plugin_dir']}/check_http"
-    parameters "--ssl -I #{local_ip} -p 5000"
+    parameters "#{backend_ssl_opt}-I #{local_ip} -p 5000"
   end
 
   nrpe_check 'check_glance_api' do
@@ -61,7 +69,7 @@ if node['osl-openstack']['node_type'] == 'controller'
 
   nrpe_check 'check_novnc' do
     command "#{node['nrpe']['plugin_dir']}/check_http"
-    parameters "--ssl -I #{local_ip} -p 6080"
+    parameters "#{backend_ssl_opt}-I #{local_ip} -p 6080"
   end
 
   nrpe_check 'check_neutron_api' do

--- a/spec/unit/recipes/mon_spec.rb
+++ b/spec/unit/recipes/mon_spec.rb
@@ -114,13 +114,16 @@ describe 'osl-openstack::mon' do
         end
 
         # Each nrpe_check should target the per-host backend IP from
-        # ha.api_listen_ip, not node['ipaddress'].
+        # ha.api_listen_ip, not node['ipaddress']. In HA the keystone
+        # and novnc backends serve plain HTTP / ws (haproxy on the VIP
+        # is the TLS endpoint), so the local check drops --ssl - check
+        # the actual backend, not what the public endpoint speaks.
         {
-          'check_keystone_api' => '--ssl -I 10.1.2.3 -p 5000',
+          'check_keystone_api' => '-I 10.1.2.3 -p 5000',
           'check_glance_api' => '-I 10.1.2.3 -p 9292',
           'check_nova_api' => '-I 10.1.2.3 -p 8774',
           'check_nova_placement_api' => '-I 10.1.2.3 -p 8778',
-          'check_novnc' => '--ssl -I 10.1.2.3 -p 6080',
+          'check_novnc' => '-I 10.1.2.3 -p 6080',
           'check_neutron_api' => '-I 10.1.2.3 -p 9696',
           'check_cinder_api' => '-I 10.1.2.3 -p 8776',
           'check_heat_api' => '-I 10.1.2.3 -p 8004',

--- a/test/integration/data_bags/openstack/ha.json
+++ b/test/integration/data_bags/openstack/ha.json
@@ -1,5 +1,8 @@
 {
   "id": "ha",
+  "database_server": {
+    "suffix": "x86"
+  },
   "ha": {
     "keepalived": {
       "primary": {

--- a/test/integration/ha/controls/ha.rb
+++ b/test/integration/ha/controls/ha.rb
@@ -86,3 +86,23 @@ control 'haproxy-vip-listeners' do
     end
   end
 end
+
+control 'mon-nrpe-checks-drop-ssl-on-ha' do
+  title 'keystone and novnc nrpe checks omit --ssl in HA'
+  # In HA the Apache backend serves plain HTTP for keystone and
+  # nova-novncproxy serves plain ws on the per-host api_listen_ip
+  # (192.168.60.11 per the ha data bag); haproxy on the VIP is the
+  # TLS endpoint. The local check has to match what the backend
+  # actually speaks, so --ssl must NOT be passed to check_http.
+  {
+    'check_keystone_api' => 5000,
+    'check_novnc' => 6080,
+  }.each do |name, port|
+    describe file("/etc/nagios/nrpe.d/#{name}.cfg") do
+      its('content') do
+        should match(%r{^command\[#{name}\]=/usr/lib64/nagios/plugins/check_http -I 192\.168\.60\.11 -p #{port}$})
+      end
+      its('content') { should_not match(/--ssl/) }
+    end
+  end
+end

--- a/test/integration/ha_master/controls/ha_master.rb
+++ b/test/integration/ha_master/controls/ha_master.rb
@@ -86,3 +86,23 @@ control 'memcached-cross-controller' do
     it { should have_rule('-A memcached -p tcp -m tcp --dport 11211 -j osl_only') }
   end
 end
+
+control 'mon-nrpe-checks-drop-ssl-on-ha' do
+  title 'keystone and novnc nrpe checks omit --ssl in HA'
+  # In HA the Apache backend serves plain HTTP for keystone and
+  # nova-novncproxy serves plain ws on the per-host api_listen_ip
+  # (10.1.2.3 for controller1 per the multinode data bag); haproxy on
+  # the VIP is the TLS endpoint. The local check has to match what the
+  # backend actually speaks, so --ssl must NOT be passed to check_http.
+  {
+    'check_keystone_api' => 5000,
+    'check_novnc' => 6080,
+  }.each do |name, port|
+    describe file("/etc/nagios/nrpe.d/#{name}.cfg") do
+      its('content') do
+        should match(%r{^command\[#{name}\]=/usr/lib64/nagios/plugins/check_http -I 10\.1\.2\.3 -p #{port}$})
+      end
+      its('content') { should_not match(/--ssl/) }
+    end
+  end
+end

--- a/test/integration/ha_standby/controls/ha_standby.rb
+++ b/test/integration/ha_standby/controls/ha_standby.rb
@@ -70,3 +70,23 @@ control 'memcached-cross-controller' do
     it { should have_rule('-A memcached -p tcp -m tcp --dport 11211 -j osl_only') }
   end
 end
+
+control 'mon-nrpe-checks-drop-ssl-on-ha' do
+  title 'keystone and novnc nrpe checks omit --ssl in HA'
+  # Symmetric with ha_master: mon runs on both controllers, gating
+  # --ssl off because the keystone Apache backend and nova-novncproxy
+  # serve plain HTTP / ws on this host's api_listen_ip (10.1.2.13 for
+  # controller2 per the multinode data bag) with haproxy on the VIP
+  # terminating TLS.
+  {
+    'check_keystone_api' => 5000,
+    'check_novnc' => 6080,
+  }.each do |name, port|
+    describe file("/etc/nagios/nrpe.d/#{name}.cfg") do
+      its('content') do
+        should match(%r{^command\[#{name}\]=/usr/lib64/nagios/plugins/check_http -I 10\.1\.2\.13 -p #{port}$})
+      end
+      its('content') { should_not match(/--ssl/) }
+    end
+  end
+end


### PR DESCRIPTION
In HA, haproxy on the VIP terminates TLS and forwards plain HTTP to
the Apache backend on the per-host api_listen_ip; nova-novncproxy
likewise serves plain ws there (--ssl_only is gated off). The local
nrpe checks talk to the backend, not the public endpoint, so --ssl
has to come off or the probe fails the TLS handshake against a
plain-HTTP listener.

- recipes/mon.rb: derive `backend_ssl_opt` from openstack_tls_on_haproxy?
  and apply it only to check_keystone_api and check_novnc - the other
  backends were already plain HTTP and stay unchanged. Non-HA single-
  controller still passes --ssl as before.

- spec/unit/recipes/mon_spec.rb: HA controller context now expects the
  two checks without --ssl; non-HA controller context unchanged.

- kitchen.yml: add recipe[osl-openstack::mon] to the ha suite's
  run_list so the gating gets exercised end-to-end on the single-node
  HA controller.

- test/integration/ha/controls/ha.rb: new control asserting the two
  /etc/nagios/nrpe.d/check_*.cfg files target api_listen_ip
  (192.168.60.11) on the right ports and contain no --ssl flag.

- main.tf: add recipe[osl-openstack::mon] to the controller1 and
  controller2 knife-bootstrap run_lists so the multi-node converge
  exercises both HA controllers' nrpe configs.

- test/integration/ha_master/controls/ha_master.rb (controller1,
  10.1.2.3) and test/integration/ha_standby/controls/ha_standby.rb
  (controller2, 10.1.2.13): parallel control blocks asserting the
  same gating per-host in the multi-node InSpec.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
