### PR TITLE
Point http-role nagios checks at the apache backend IP in HA

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -330,6 +330,7 @@ suites:
         - test/integration/compute
         - test/integration/compute_controller
         - test/integration/controller
+        - test/integration/dashboard
         - test/integration/identity
         - test/integration/image
         - test/integration/network

--- a/recipes/dashboard.rb
+++ b/recipes/dashboard.rb
@@ -29,6 +29,25 @@ include_recipe 'osl-apache'
 include_recipe 'osl-apache::mod_wsgi'
 include_recipe 'osl-apache::mod_ssl'
 
+# Nagios apache monitoring. check_http runs locally over NRPE (configured by
+# osl-apache::mon via the apache role, invoked server-side by the apache_httpd
+# check), so point it at whatever address apache actually listens on: the
+# per-host backend IP in HA, or node['ipaddress'] on a single-controller
+# deploy (openstack_local_api_endpoint already returns the latter off-HA, so
+# this is a no-op there). Declare the check here with the override already set
+# - before osl-apache::mon's own include - because the nrpe check captures its
+# -I at compile time on first include.
+node.override['osl-nrpe']['check_http']['ipaddress'] = openstack_local_api_endpoint
+
+# In HA apache binds an IPv4-only backend IP and serves no IPv6 of its own -
+# IPv6 clients terminate on the haproxy VIP - so drop this controller from the
+# per-host apache_http6 check. The VIP is monitored separately via its own
+# (unmanaged) Nagios host. Off-HA apache still binds wildcard and serves the
+# public IPv6, so the check stays.
+node.override['nagios']['_http_address6'] = nil if openstack_tls_on_haproxy?
+
+include_recipe 'osl-nrpe::check_http'
+
 package 'openstack-dashboard'
 
 certificate_manage 'wildcard-dashboard' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,246 +29,250 @@ ALL_PLATFORMS = [
   ALMA_8,
 ].freeze
 
-shared_context 'common_stubs' do
-  before do
-    stub_data_bag_item('openstack', 'x86').and_return(
-      'block-storage' => {
-        'ceph' => {
-          "backup_ceph_pool": 'backups',
-          "block_backup_rbd_store_user": 'cinder-backup',
-          "block_backup_token": 'AQAxbr1ac4ToKhAAeO6+h90GcsukzHicUNvfLg==',
-          "block_rbd_pool": 'volumes',
-          "block_ssd_rbd_pool": 'volumes_ssd',
-          "block_token": 'AQAjbr1aWv+aNBAAoGfqrwX9iSdNmtuvUkwGhA==',
-          "rbd_store_user": 'cinder',
-        },
-        'db' => {
-          "user": 'cinder',
-          "pass": 'cinder',
-        },
-        "endpoint": 'controller.testing.osuosl.org',
-        "region": 'RegionOne',
-        'service' => {
-          "user": 'cinder',
-          "pass": 'cinder',
-        },
+def openstack_secrets_stub
+  {
+    'block-storage' => {
+      'ceph' => {
+        "backup_ceph_pool": 'backups',
+        "block_backup_rbd_store_user": 'cinder-backup',
+        "block_backup_token": 'AQAxbr1ac4ToKhAAeO6+h90GcsukzHicUNvfLg==',
+        "block_rbd_pool": 'volumes',
+        "block_ssd_rbd_pool": 'volumes_ssd',
+        "block_token": 'AQAjbr1aWv+aNBAAoGfqrwX9iSdNmtuvUkwGhA==',
+        "rbd_store_user": 'cinder',
       },
-      'compute_api' => {
-        'db' => {
-          "user": 'nova',
-          "pass": 'nova',
-        },
+      'db' => {
+        "user": 'cinder',
+        "pass": 'cinder',
       },
-      'compute_cell0' => {
-        'db' => {
-          "user": 'nova',
-          "pass": 'nova',
-        },
+      "endpoint": 'controller.testing.osuosl.org',
+      "region": 'RegionOne',
+      'service' => {
+        "user": 'cinder',
+        "pass": 'cinder',
       },
-      'compute' => {
-        'ceph' => {
-          "block_token": 'AQAjbr1aWv+aNBAAoGfqrwX9iSdNmtuvUkwGhA==',
-          "images_rbd_pool": 'vms',
-          "rbd_user": 'cinder',
-        },
-        "disk_allocation_ratio": '1.5',
-        'db' => {
-          "user": 'nova',
-          "pass": 'nova',
-        },
-        'enabled_filters' => %w(
-          AggregateInstanceExtraSpecsFilter
-          PciPassthroughFilter
-          AvailabilityZoneFilter
-          ComputeFilter
-          ComputeCapabilitiesFilter
-          ImagePropertiesFilter
-          ServerGroupAntiAffinityFilter
-          ServerGroupAffinityFilter
-        ),
-        "endpoint": 'controller.testing.osuosl.org',
-        "region": 'RegionOne',
-        'libvirt_guests' => {
-          "on_boot": 'ignore',
-          "on_shutdown": 'shutdown',
-          "parallel_shutdown": '25',
-          "shutdown_timeout": '120',
-        },
-        'ksm' => {
-          'npages_max' => 2500,
-          'thres_coef' => 25,
-          'monitor_interval' => 30,
-        },
-        'local_storage' => {
-          'node1.testing.osuosl.org' => true,
-        },
-        "nova_migration_key": "----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA2Dri5D9Rf0pv3QiQAO5JnvjmzuCfMdh62VONFvEKluMhakTy\np1uR2C3lKUcyBc1np/yyJ+kepcU30gJ5w/KhBLimxYx+VkaiWAiXgMmkwU0clNRR\n5XE0fxEPx1Wd/E0MAs7WYG6BW+c5lqmHN/wWARxgOl3mDeY0XB72W8mhi/mANfyj\nyI6W0H6iD13R36HaEjV+KkEHHGAatnP66tz7oe0PaFaYemtpatMFrKmMqtL0xhzy\nhWEoVacA5dmd3PHgdz+8hUczkdlTbnsyZToKB8+g/5gTmy49Z/sotO23Bm6cAB/6\nyxMosuIFXa7tqkAHGwy/WIm5PepaL4pvyB+HVQIDAQABAoIBAQCgKE2yPewBWoMs\ntpDi/5xsMXPTu7BuXSfxHN+eJH9xb15qthL9PufxtVzNjDxS6+dhF9xlj1fx9Pf5\nh3flWStGsfZk0EErajoI9qQw8iokOxd2bSUTyxvVGjATtyjDndXNpqJG3tLV3Zhc\nLclIAGHUBM6JrM8fcGlL6msTZW9QmupEU69ih0rHGR50in2e+Ofp6TWPbwH2PoRn\nvj3SOyBAOfZMpsTweYwZm/FhkpSY+lxXbsPgEasJNm0/F46U7CHlQVSUY248Y+eB\nDzNI7MC5bknqbWg0TDOQtw41RLaGdVUQy9wqC/UlOWb4mteEZXIx3tfNb5W/5V7G\nYedSjwgpAoGBAPQiCzsWTdC7cR9YbF4d8Tv9uKNCmZG1Q4dxTnhQJcSFsBTr2f2a\nps3Ej3nW0wQZfVOVaU6dUcyQxgm4x2fi+TqhAVGdRLSA8iSJTpC99RUn/JdAW/UA\ngvGI0iCrkq/BYCjjrKI7ZsHv6urE3I0jnh5+H969BsZ6XR6IntwmDshrAoGBAOK9\nnzlOEZO54VGTRuBF1m0E3GBsVDhrsoFpZSVcgv3h84MK2idMP0XvEBxvOI/I2hGI\nkVJ23axxWEmpGzWrBNuJrC0sQKD3g6rdwXSwPsGk0OEXyQVrC3LfLZf3iS+GDSI7\nUYPL01joCXy99fQPCf/dCdpviAlZVO/mlO4Tdd8/AoGAHEQk0L6QW+6X9m0ifvMw\njyWdTynS5g/6tZ/k2gFNnidsb7+vCbHyRjjP8+dvnzXkUN0nyDZm1iydAVsnm1uo\nR6WEpZJz9gJIBvru4ctcqQpsMIb/Hqrkflq9GZND9J2LKLDTuCTwjNveczg/4QeS\nsy0fO4bfVfOs/HANFKhDZekCgYBnEalyZDGLRIDPEzKxui1Zy07eKgAy0YoIV7+Z\nty74d6C5HdLC8F8GzEA3nLtKaRPvynO817m2rKNkgJGU2NPRdAinVClgwoLAxiMt\nhvxQDDrDR4uigeFna1oPbX+X8cjAmdRZI+tDy96cLMHEGp4CCBl1iSN+lHQOxXNH\nseLwAwKBgQDx5QqwZOfmlQ0rx6jf2EoHChbS3JYt1cRJbwzIOakcKh2Jn/agxZJ8\ne9o0x8HI89mJd1WejorvSVN1c3IgV5TG10k5PcmOxlv1OhGNFzWgvMXZmvCwwP40\nX0BwCgHRB7FvPAMu0hrDmEIJ87edGd1ziRYXpA9Lke/4VQk249pwzA==\n-----END RSA PRIVATE KEY-----",
-        "nova_public_key": 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYOuLkP1F/Sm/dCJAA7kme+ObO4J8x2HrZU40W8QqW4yFqRPKnW5HYLeUpRzIFzWen/LIn6R6lxTfSAnnD8qEEuKbFjH5WRqJYCJeAyaTBTRyU1FHlcTR/EQ/HVZ38TQwCztZgboFb5zmWqYc3/BYBHGA6XeYN5jRcHvZbyaGL+YA1/KPIjpbQfqIPXdHfodoSNX4qQQccYBq2c/rq3Puh7Q9oVph6a2lq0wWsqYyq0vTGHPKFYShVpwDl2Z3c8eB3P7yFRzOR2VNuezJlOgoHz6D/mBObLj1n+yi07bcGbpwAH/rLEyiy4gVdru2qQAcbDL9Yibk96lovim/IH4dV nova-migration',
-        'pci_alias' => {
-          'controller2.testing.osuosl.org' => '{ "vendor_id": "10de", "product_id": "1db5", "device_type": "type-PCI", "name": "gpu_nvidia_v100" }',
-          'node1.testing.osuosl.org' => '{ "vendor_id": "10de", "product_id": "1db5", "device_type": "type-PCI", "name": "gpu_nvidia_v100" }',
-        },
-        'pci_passthrough_whitelist' => {
-          'node1.testing.osuosl.org' => '{ "vendor_id": "10de", "product_id": "1db5" }',
-        },
-        'service' => {
-          "user": 'nova',
-          "pass": 'nova',
-        },
+    },
+    'compute_api' => {
+      'db' => {
+        "user": 'nova',
+        "pass": 'nova',
       },
-      'dashboard' => {
-        "aliases": [
-          'controller1.testing.osuosl.org',
-        ],
-        "endpoint": 'controller.testing.osuosl.org',
-        'db' => {
-          "user": 'horizon',
-          "pass": 'horizon',
-        },
-        'regions' => {
-          "RegionOne": 'https://controller.testing.osuosl.org:5000/v3',
-          "RegionTwo": 'https://controller.testing.osuosl.org:5000/v3',
-        },
-        "secret_key": '-#45g2*o=8mhe(10if%*65@g#z0r#r7m__w6kwq8s9@n%12a11',
+    },
+    'compute_cell0' => {
+      'db' => {
+        "user": 'nova',
+        "pass": 'nova',
       },
-      'database_server' => {
-        "suffix": 'x86',
-        "endpoint": 'localhost',
+    },
+    'compute' => {
+      'ceph' => {
+        "block_token": 'AQAjbr1aWv+aNBAAoGfqrwX9iSdNmtuvUkwGhA==',
+        "images_rbd_pool": 'vms',
+        "rbd_user": 'cinder',
       },
-      'identity' => {
-        "aliases": [
-          'controller1.testing.osuosl.org',
-        ],
-        "endpoint": 'controller.testing.osuosl.org',
-        'db' => {
-          "user": 'keystone',
-          "pass": 'keystone',
-        },
+      "disk_allocation_ratio": '1.5',
+      'db' => {
+        "user": 'nova',
+        "pass": 'nova',
       },
-      'image' => {
-        "endpoint": 'controller.testing.osuosl.org',
-        "region": 'RegionOne',
-        'db' => {
-          "user": 'glance',
-          "pass": 'glance',
-        },
-        'ceph' => {
-          "image_token": 'AQANbr1aPR2EIhAASn5EW+qjhoXJAtIqGYE5jQ==',
-          "rbd_store_pool": 'images',
-          "rbd_store_user": 'glance',
-        },
-        'local_storage' => {
-          'node1.testing.osuosl.org' => true,
-        },
-        'service' => {
-          "user": 'glance',
-          "pass": 'glance',
-        },
+      'enabled_filters' => %w(
+        AggregateInstanceExtraSpecsFilter
+        PciPassthroughFilter
+        AvailabilityZoneFilter
+        ComputeFilter
+        ComputeCapabilitiesFilter
+        ImagePropertiesFilter
+        ServerGroupAntiAffinityFilter
+        ServerGroupAffinityFilter
+      ),
+      "endpoint": 'controller.testing.osuosl.org',
+      "region": 'RegionOne',
+      'libvirt_guests' => {
+        "on_boot": 'ignore',
+        "on_shutdown": 'shutdown',
+        "parallel_shutdown": '25',
+        "shutdown_timeout": '120',
       },
-      'messaging' => {
-        "endpoint": 'controller.testing.osuosl.org',
-        "user": 'openstack',
-        "pass": 'openstack',
+      'ksm' => {
+        'npages_max' => 2500,
+        'thres_coef' => 25,
+        'monitor_interval' => 30,
       },
-      'memcached' => {
-        "endpoint": 'controller.testing.osuosl.org:11211',
+      'local_storage' => {
+        'node1.testing.osuosl.org' => true,
       },
-      'network' => {
-        "endpoint": 'controller.testing.osuosl.org',
-        "region": 'RegionOne',
-        'db' => {
-          "user": 'neutron',
-          "pass": 'neutron',
-        },
-        "nova_metadata_host": 'controller.testing.osuosl.org',
-        "metadata_proxy_shared_secret": '2SJh0RuO67KpZ63z',
-        'physical_interface_mappings' => [
-          {
-            "name": 'public',
-            'subnet': '10.0.0.0/24',
-            'uuid': '8df74e06-c4aa-4eb2-b312-0e915bf8f97f',
-            'controller' => {
-              "default": 'eth1',
-              "controller2.testing.osuosl.org": 'p1p2',
-            },
-            'compute' => {
-              "default": 'eth1',
-              "node1.testing.osuosl.org": 'eno1',
-            },
-          },
-          {
-            "name": 'private1',
-            'controller' => {
-              "default": 'disabled',
-            },
-            'compute' => {
-              "default": 'disabled',
-            },
-          },
-        ],
-        'service' => {
-          "user": 'neutron',
-          "pass": 'neutron',
-        },
-        'vxlan_interface' => {
+      "nova_migration_key": "----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA2Dri5D9Rf0pv3QiQAO5JnvjmzuCfMdh62VONFvEKluMhakTy\np1uR2C3lKUcyBc1np/yyJ+kepcU30gJ5w/KhBLimxYx+VkaiWAiXgMmkwU0clNRR\n5XE0fxEPx1Wd/E0MAs7WYG6BW+c5lqmHN/wWARxgOl3mDeY0XB72W8mhi/mANfyj\nyI6W0H6iD13R36HaEjV+KkEHHGAatnP66tz7oe0PaFaYemtpatMFrKmMqtL0xhzy\nhWEoVacA5dmd3PHgdz+8hUczkdlTbnsyZToKB8+g/5gTmy49Z/sotO23Bm6cAB/6\nyxMosuIFXa7tqkAHGwy/WIm5PepaL4pvyB+HVQIDAQABAoIBAQCgKE2yPewBWoMs\ntpDi/5xsMXPTu7BuXSfxHN+eJH9xb15qthL9PufxtVzNjDxS6+dhF9xlj1fx9Pf5\nh3flWStGsfZk0EErajoI9qQw8iokOxd2bSUTyxvVGjATtyjDndXNpqJG3tLV3Zhc\nLclIAGHUBM6JrM8fcGlL6msTZW9QmupEU69ih0rHGR50in2e+Ofp6TWPbwH2PoRn\nvj3SOyBAOfZMpsTweYwZm/FhkpSY+lxXbsPgEasJNm0/F46U7CHlQVSUY248Y+eB\nDzNI7MC5bknqbWg0TDOQtw41RLaGdVUQy9wqC/UlOWb4mteEZXIx3tfNb5W/5V7G\nYedSjwgpAoGBAPQiCzsWTdC7cR9YbF4d8Tv9uKNCmZG1Q4dxTnhQJcSFsBTr2f2a\nps3Ej3nW0wQZfVOVaU6dUcyQxgm4x2fi+TqhAVGdRLSA8iSJTpC99RUn/JdAW/UA\ngvGI0iCrkq/BYCjjrKI7ZsHv6urE3I0jnh5+H969BsZ6XR6IntwmDshrAoGBAOK9\nnzlOEZO54VGTRuBF1m0E3GBsVDhrsoFpZSVcgv3h84MK2idMP0XvEBxvOI/I2hGI\nkVJ23axxWEmpGzWrBNuJrC0sQKD3g6rdwXSwPsGk0OEXyQVrC3LfLZf3iS+GDSI7\nUYPL01joCXy99fQPCf/dCdpviAlZVO/mlO4Tdd8/AoGAHEQk0L6QW+6X9m0ifvMw\njyWdTynS5g/6tZ/k2gFNnidsb7+vCbHyRjjP8+dvnzXkUN0nyDZm1iydAVsnm1uo\nR6WEpZJz9gJIBvru4ctcqQpsMIb/Hqrkflq9GZND9J2LKLDTuCTwjNveczg/4QeS\nsy0fO4bfVfOs/HANFKhDZekCgYBnEalyZDGLRIDPEzKxui1Zy07eKgAy0YoIV7+Z\nty74d6C5HdLC8F8GzEA3nLtKaRPvynO817m2rKNkgJGU2NPRdAinVClgwoLAxiMt\nhvxQDDrDR4uigeFna1oPbX+X8cjAmdRZI+tDy96cLMHEGp4CCBl1iSN+lHQOxXNH\nseLwAwKBgQDx5QqwZOfmlQ0rx6jf2EoHChbS3JYt1cRJbwzIOakcKh2Jn/agxZJ8\ne9o0x8HI89mJd1WejorvSVN1c3IgV5TG10k5PcmOxlv1OhGNFzWgvMXZmvCwwP40\nX0BwCgHRB7FvPAMu0hrDmEIJ87edGd1ziRYXpA9Lke/4VQk249pwzA==\n-----END RSA PRIVATE KEY-----",
+      "nova_public_key": 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYOuLkP1F/Sm/dCJAA7kme+ObO4J8x2HrZU40W8QqW4yFqRPKnW5HYLeUpRzIFzWen/LIn6R6lxTfSAnnD8qEEuKbFjH5WRqJYCJeAyaTBTRyU1FHlcTR/EQ/HVZ38TQwCztZgboFb5zmWqYc3/BYBHGA6XeYN5jRcHvZbyaGL+YA1/KPIjpbQfqIPXdHfodoSNX4qQQccYBq2c/rq3Puh7Q9oVph6a2lq0wWsqYyq0vTGHPKFYShVpwDl2Z3c8eB3P7yFRzOR2VNuezJlOgoHz6D/mBObLj1n+yi07bcGbpwAH/rLEyiy4gVdru2qQAcbDL9Yibk96lovim/IH4dV nova-migration',
+      'pci_alias' => {
+        'controller2.testing.osuosl.org' => '{ "vendor_id": "10de", "product_id": "1db5", "device_type": "type-PCI", "name": "gpu_nvidia_v100" }',
+        'node1.testing.osuosl.org' => '{ "vendor_id": "10de", "product_id": "1db5", "device_type": "type-PCI", "name": "gpu_nvidia_v100" }',
+      },
+      'pci_passthrough_whitelist' => {
+        'node1.testing.osuosl.org' => '{ "vendor_id": "10de", "product_id": "1db5" }',
+      },
+      'service' => {
+        "user": 'nova',
+        "pass": 'nova',
+      },
+    },
+    'dashboard' => {
+      "aliases": [
+        'controller1.testing.osuosl.org',
+      ],
+      "endpoint": 'controller.testing.osuosl.org',
+      'db' => {
+        "user": 'horizon',
+        "pass": 'horizon',
+      },
+      'regions' => {
+        "RegionOne": 'https://controller.testing.osuosl.org:5000/v3',
+        "RegionTwo": 'https://controller.testing.osuosl.org:5000/v3',
+      },
+      "secret_key": '-#45g2*o=8mhe(10if%*65@g#z0r#r7m__w6kwq8s9@n%12a11',
+    },
+    'database_server' => {
+      "suffix": 'x86',
+      "endpoint": 'localhost',
+    },
+    'identity' => {
+      "aliases": [
+        'controller1.testing.osuosl.org',
+      ],
+      "endpoint": 'controller.testing.osuosl.org',
+      'db' => {
+        "user": 'keystone',
+        "pass": 'keystone',
+      },
+    },
+    'image' => {
+      "endpoint": 'controller.testing.osuosl.org',
+      "region": 'RegionOne',
+      'db' => {
+        "user": 'glance',
+        "pass": 'glance',
+      },
+      'ceph' => {
+        "image_token": 'AQANbr1aPR2EIhAASn5EW+qjhoXJAtIqGYE5jQ==',
+        "rbd_store_pool": 'images',
+        "rbd_store_user": 'glance',
+      },
+      'local_storage' => {
+        'node1.testing.osuosl.org' => true,
+      },
+      'service' => {
+        "user": 'glance',
+        "pass": 'glance',
+      },
+    },
+    'messaging' => {
+      "endpoint": 'controller.testing.osuosl.org',
+      "user": 'openstack',
+      "pass": 'openstack',
+    },
+    'memcached' => {
+      "endpoint": 'controller.testing.osuosl.org:11211',
+    },
+    'network' => {
+      "endpoint": 'controller.testing.osuosl.org',
+      "region": 'RegionOne',
+      'db' => {
+        "user": 'neutron',
+        "pass": 'neutron',
+      },
+      "nova_metadata_host": 'controller.testing.osuosl.org',
+      "metadata_proxy_shared_secret": '2SJh0RuO67KpZ63z',
+      'physical_interface_mappings' => [
+        {
+          "name": 'public',
+          'subnet': '10.0.0.0/24',
+          'uuid': '8df74e06-c4aa-4eb2-b312-0e915bf8f97f',
           'controller' => {
-            "default": 'lo',
-            "controller2.testing.osuosl.org": 'p2p1',
+            "default": 'eth1',
+            "controller2.testing.osuosl.org": 'p1p2',
           },
           'compute' => {
-            "default": 'lo',
-            "node1.testing.osuosl.org": 'eno2',
+            "default": 'eth1',
+            "node1.testing.osuosl.org": 'eno1',
           },
         },
-      },
-      'openrc' => {
-        "region": 'RegionOne',
-      },
-      'orchestration' => {
-        "auth_encryption_key": '4CFk1URr4Ln37kKRNSypwjI7vv7jfLQE',
-        "region": 'RegionOne',
-        'db' => {
-          "user": 'heat',
-          "pass": 'heat',
+        {
+          "name": 'private1',
+          'controller' => {
+            "default": 'disabled',
+          },
+          'compute' => {
+            "default": 'disabled',
+          },
         },
-        "endpoint": 'controller.testing.osuosl.org',
-        "heat_domain_admin": 'heat_domain_admin',
-        'service' => {
-          "user": 'heat',
-          "pass": 'heat',
-        },
+      ],
+      'service' => {
+        "user": 'neutron',
+        "pass": 'neutron',
       },
-      'placement' => {
-        "endpoint": 'controller.testing.osuosl.org',
-        "region": 'RegionOne',
-        'db' => {
-          "user": 'placement',
-          "pass": 'placement',
+      'vxlan_interface' => {
+        'controller' => {
+          "default": 'lo',
+          "controller2.testing.osuosl.org": 'p2p1',
         },
-        'service' => {
-          "user": 'placement',
-          "pass": 'placement',
+        'compute' => {
+          "default": 'lo',
+          "node1.testing.osuosl.org": 'eno2',
         },
       },
-      'telemetry' => {
-        'db' => {
-          "user": 'ceilometer',
-          "pass": 'ceilometer',
-        },
-        'pipeline' => {
-          'publishers' => [
-            'prometheus://localhost:9091/metrics/job/ceilometer',
-          ],
-        },
-        'service' => {
-          "user": 'ceilometer',
-          "pass": 'ceilometer',
-        },
+    },
+    'openrc' => {
+      "region": 'RegionOne',
+    },
+    'orchestration' => {
+      "auth_encryption_key": '4CFk1URr4Ln37kKRNSypwjI7vv7jfLQE',
+      "region": 'RegionOne',
+      'db' => {
+        "user": 'heat',
+        "pass": 'heat',
       },
-      'users' => {
-        "admin": 'admin',
-      }
-    )
+      "endpoint": 'controller.testing.osuosl.org',
+      "heat_domain_admin": 'heat_domain_admin',
+      'service' => {
+        "user": 'heat',
+        "pass": 'heat',
+      },
+    },
+    'placement' => {
+      "endpoint": 'controller.testing.osuosl.org',
+      "region": 'RegionOne',
+      'db' => {
+        "user": 'placement',
+        "pass": 'placement',
+      },
+      'service' => {
+        "user": 'placement',
+        "pass": 'placement',
+      },
+    },
+    'telemetry' => {
+      'db' => {
+        "user": 'ceilometer',
+        "pass": 'ceilometer',
+      },
+      'pipeline' => {
+        'publishers' => [
+          'prometheus://localhost:9091/metrics/job/ceilometer',
+        ],
+      },
+      'service' => {
+        "user": 'ceilometer',
+        "pass": 'ceilometer',
+      },
+    },
+    'users' => {
+      "admin": 'admin',
+    },
+  }
+end
+
+shared_context 'common_stubs' do
+  before do
+    stub_data_bag_item('openstack', 'x86').and_return(openstack_secrets_stub)
     stubs_for_resource('execute[rabbitmq: add user openstack]') do |resource|
       allow(resource).to receive_shell_out('rabbitmqctl -q list_users')
     end

--- a/spec/unit/recipes/dashboard_spec.rb
+++ b/spec/unit/recipes/dashboard_spec.rb
@@ -18,8 +18,14 @@ describe 'osl-openstack::dashboard' do
         osl-apache
         osl-apache::mod_wsgi
         osl-apache::mod_ssl
+        osl-nrpe::check_http
       ).each do |r|
         it { is_expected.to include_recipe r }
+      end
+      # Off-HA the apache check_http targets node['ipaddress'] (the
+      # openstack_local_api_endpoint fallback), so this override is a no-op.
+      it do
+        expect(chef_run.node['osl-nrpe']['check_http']['ipaddress']).to eq('10.0.0.2')
       end
       # memcached setup lives in ::identity (runs first via controller.rb).
       it { is_expected.to_not include_recipe 'osl-memcached' }
@@ -133,6 +139,40 @@ describe 'osl-openstack::dashboard' do
         end
         it do
           is_expected.to_not render_file('/etc/openstack-dashboard/local_settings').with_content('DEFAULT_SERVICE_REGIONS')
+        end
+      end
+
+      context 'HA controller' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm) do |node|
+            node.automatic['fqdn'] = 'controller1.testing.osuosl.org'
+            node.automatic['ip6address'] = '2605:bc80:3010::140'
+          end.converge(described_recipe)
+        end
+
+        include_context 'common_stubs'
+        before do
+          stub_data_bag_item('openstack', 'x86').and_return(
+            openstack_secrets_stub.merge(
+              'ha' => {
+                'api_listen_ip' => {
+                  'controller1.testing.osuosl.org' => '10.1.2.3',
+                },
+              }
+            )
+          )
+        end
+
+        # The apache check_http runs locally via NRPE, so it must dial the
+        # per-host backend IP apache binds in HA, not the public address.
+        it do
+          expect(chef_run.node['osl-nrpe']['check_http']['ipaddress']).to eq('10.1.2.3')
+        end
+        # Apache serves no IPv6 of its own in HA (the VIP does), so this
+        # controller drops out of the per-host apache_http6 check even though
+        # it has a public IPv6.
+        it do
+          expect(chef_run.node['nagios']['_http_address6']).to be_nil
         end
       end
     end

--- a/test/integration/dashboard/controls/dashboard_spec.rb
+++ b/test/integration/dashboard/controls/dashboard_spec.rb
@@ -103,3 +103,24 @@ control 'openstack-dashboard' do
     end
   end
 end
+
+control 'dashboard-nrpe-http' do
+  title 'apache check_http points at the apache listen IP'
+  desc <<~DESC
+    osl-openstack::dashboard pulls in osl-nrpe::check_http and overrides the
+    check's target to openstack_local_api_endpoint - the per-host backend IP
+    apache binds in HA, or the node's primary address on a single-controller
+    deploy. Before this wiring the dashboard node had no check_http.cfg at
+    all, so its presence (with a real -I address and the redirect-friendly
+    accepted codes) confirms the override path is in place.
+  DESC
+
+  plugin_dir = '/usr/lib64/nagios/plugins'
+
+  describe file('/etc/nagios/nrpe.d/check_http.cfg') do
+    it { should exist }
+    its('content') { should include "command[check_http]=#{plugin_dir}/check_http" }
+    its('content') { should match(/-I \d{1,3}(\.\d{1,3}){3}\b/) }
+    its('content') { should match(/-e 200,301,302,308/) }
+  end
+end


### PR DESCRIPTION
- Override check_http's target to openstack_local_api_endpoint so the
  http role's local NRPE check hits the per-host backend IP apache binds
  in HA (node['ipaddress'] off-HA, a no-op there)
- Include osl-nrpe::check_http explicitly so the override wins
  regardless of run-list order
- Null out _http_address6 in HA so the controller drops out of the
  per-host apache_http6 check (apache serves no IPv6 there; the VIP is
  monitored separately)
- Extract the spec secrets into openstack_secrets_stub so the dashboard
  HA spec can merge in ha.api_listen_ip
- Add a dashboard inspec control asserting check_http.cfg is present and
  targets the apache listen IP, and run the dashboard profile in the
  allinone suite too

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
