### PR TITLE
Messaging tier: production deployment docs + chef-managed plugins

### DIFF
--- a/docs/SHARED_MESSAGING_TIER.md
+++ b/docs/SHARED_MESSAGING_TIER.md
@@ -1,6 +1,9 @@
 # Design: shared 3-node RabbitMQ messaging tier
 
-Status: proposal / pre-implementation.
+Status: implemented in the cookbook and validated in the multi-node test
+env (3-node EL10 tier, TLS-only, CMR, quorum queues verified). See
+[Production deployment](#production-deployment-bringing-the-tier-online)
+for the build-out steps.
 
 ## Motivation
 
@@ -118,11 +121,10 @@ the controllers — they no longer host a broker.
    holds 2 of 3), validating the production topology in CI before any
    real cloud cuts over. This is also the rig to develop the
    `messaging.vhost` helper and tier-provisioning recipe against.
-   **Status: unimplemented** — no `mq*` nodes exist, `main.tf` still
-   gives the controllers `ops_messaging`, `multinode.json` still has the
-   embedded 2-node schema, and the kitchen/terraform platforms are
-   EL8/EL9 only (no EL10 target for a 4.2 tier). Until this lands, the
-   "CI proves the production topology" claim is **not yet met**.
+   **Status: done** — `main.tf` deploys mq1/mq2/mq3 (EL10, converged
+   before the controllers), the controllers no longer run
+   `ops_messaging`, and inspec asserts the 3-node cluster, CMR, TLS-only
+   listener, and a real quorum queue in the cloud vhost.
 7. **RabbitMQ 4.2 repo support — DONE.** `openstack_rabbitmq_repo`
    ([libraries/helpers.rb:52-64](../libraries/helpers.rb#L52)) now has a
    `when 10` arm pointing at the SIG **`rabbitmq-4`** subdir (4.x).
@@ -132,16 +134,143 @@ the controllers — they no longer host a broker.
    Messaging key in `resources/messaging.rb` signs `rabbitmq-4` too.
    Remaining: an EL10 test platform to exercise it in CI (change 6).
 
+## Production deployment: bringing the tier online
+
+This is Phase 0 of the migration in concrete steps — build and verify
+the tier once, before any cloud cuts over. Everything the broker needs
+(repo, package, dir ownership, cookie, clustering, TLS, vhosts, CMR,
+firewall) is handled by `osl-openstack::ops_messaging`; the manual work
+is VMs, DNS, a data bag, a role, and converge order.
+
+### 1. Provision the VMs
+
+Three identical Ganeti VMs per [VM specs](#vm-specs): **AlmaLinux 10**,
+8 vCPU / 16 GB / 60-100 GB **plain (local) SSD** disk — no DRBD — and
+**one per physical host** (anti-affinity is load-bearing; see VM specs).
+Add DNS A records for `mq1`/`mq2`/`mq3.bak.osuosl.org`. The standard
+wildcard cert does not cover this domain, so the tier needs a
+`*.bak.osuosl.org` cert in its own `certificates` bag item, selected via
+`messaging.ssl_search_id` (step 2).
+
+### 2. Create the tier data bag item
+
+The mq nodes read their own encrypted `openstack` bag item — they are
+not part of any cloud's item. Generate the Erlang cookie and per-cloud
+passwords (`openssl rand -hex 20` each):
+
+```json
+{
+  "id": "messaging_tier",
+  "messaging": {
+    "user": "openstack",
+    "pass": "<admin pass>",
+    "cookie": "<cookie>",
+    "primary_node": "rabbit@mq1.bak.osuosl.org",
+    "tls": true,
+    "tls_only": true,
+    "ssl_search_id": "wildcard-bak",
+    "cmr_target_group_size": 3,
+    "vhosts": [
+      { "vhost": "arm",   "user": "arm",   "pass": "<arm pass>" },
+      { "vhost": "ppc64", "user": "ppc64", "pass": "<ppc64 pass>" },
+      { "vhost": "x86",   "user": "x86",   "pass": "<x86 pass>" }
+    ]
+  }
+}
+```
+
+`tls_only: true` from day one: no cloud ever speaks plaintext to the
+tier (each arrives with `messaging.tls` at its cutover), so 5672 never
+needs to be offered. `ssl_search_id` names the `certificates` bag item
+holding the `*.bak.osuosl.org` cert (`wildcard-bak` here; defaults to
+`wildcard` when unset).
+
+### 3. Create the role
+
+`roles/openstack_messaging.json`, mirroring how the per-cloud roles
+select their bag item:
+
+```json
+{
+  "name": "openstack_messaging",
+  "description": "Shared RabbitMQ messaging tier node",
+  "json_class": "Chef::Role",
+  "chef_type": "role",
+  "run_list": [
+    "recipe[osl-openstack::ops_messaging]",
+    "recipe[osl-openstack::mon]"
+  ],
+  "default_attributes": {
+    "osl-openstack": {
+      "databag_item": "messaging_tier",
+      "node_type": "messaging"
+    }
+  }
+}
+```
+
+Requires the osl-firewall release with 5671/15692 in `rabbitmq_mgt`
+(already merged) — the resource opens all tier ports itself, OSL-only.
+
+### 4. Bootstrap, then converge in order: mq1 first
+
+Bootstrap all three nodes with the normal method (no role), then add
+the role and converge **one node at a time, mq1 (the primary) first** —
+it starts the broker, writes the TLS config, and creates the three
+vhosts/users. mq2 and mq3 join mq1 (`join_cluster`) and receive the
+vhosts/users via Khepri replication.
+
+```
+# per node, mq1 first:
+knife node edit mq1.bak.osuosl.org   # add role[openstack_messaging] to the run list
+ssh mq1.bak.osuosl.org sudo cinc-client
+# verify (step 5 subset), then repeat for mq2, then mq3
+```
+
+### 5. Verify the tier
+
+```
+# on each mq node
+rabbitmqctl cluster_status              # 3 running nodes, khepri store
+rabbitmqctl -t 60 await_online_nodes 3
+rabbitmqctl -q list_vhosts              # arm / ppc64 / x86 on ALL nodes
+ss -tlnp | grep -E ':(5671|5672)'       # 5671 listening, 5672 absent
+
+# from a controller of each cloud (reachability + cert)
+openssl s_client -connect mq1.bak.osuosl.org:5671 -brief </dev/null
+```
+
+`list_vhosts` succeeding on mq2/mq3 doubles as the replication check —
+the vhosts only exist there via Khepri.
+
+### 6. Monitoring — before the first cutover
+
+Chef handles the node side: the management + prometheus plugins are
+enabled by default (`messaging.plugins` overrides), the mon recipe
+(via `node_type: messaging`) installs the NRPE checks from
+[Security & monitoring](#security--monitoring), and the Prometheus
+server scrapes the tier via the `rabbitmq` job in
+`osl-prometheus::server`. Remaining manual work: the Nagios server
+service definitions for the new checks, the alert rules, and the
+3-VMs-on-3-distinct-Ganeti-hosts check. Paging on quorum loss is the
+blast-radius mitigation — it must exist before a cloud depends on the
+tier.
+
+### 7. Failover validation
+
+While nothing depends on the tier yet, reboot one mq node: the other
+two must keep serving (`await_online_nodes 2` succeeds), and the
+rebooted node must rejoin to 3. This is the exact failure the tier
+exists to survive — cheapest to prove now.
+
+Then start the per-cloud cutovers below, in the decided order
+`arm → ppc64 → x86`.
+
 ## Migration (per cloud, one at a time)
 
-Stand up the tier first, then cut each cloud over in its own window.
-
-**Phase 0 — build the tier (once):**
-1. Provision 3 rabbit VMs; cluster them; verify `cluster_status` shows
-   3 running nodes, `partitions: (none)`, and the Khepri metadata store.
-   Configure the TLS listener (5671, wildcard cert) and open the tier
-   firewall (5671, plus 5672 during migration) to the cloud subnets.
-2. Pre-create each cloud's vhost + user.
+Stand up the tier first
+([Production deployment](#production-deployment-bringing-the-tier-online)),
+then cut each cloud over in its own window.
 
 **Phase N — cut over one cloud:**
 1. Pause the chef-client cron on that cloud's controllers + hypervisors.
@@ -217,9 +346,12 @@ tier node → quorum holds (2 of 3) → all clouds keep RPC.
 ### TLS (decided: yes — TLS on 5671, wildcard cert)
 
 Per-cloud AMQP creds now cross the network to a shared tier, so
-client↔broker traffic is TLS. **Reuse the existing wildcard cert** (the
-`certificates/wildcard` data bag haproxy already uses): `*.<domain>`
-covers `mq1`/`mq2`/`mq3.<domain>`, so one cert serves all three nodes.
+client↔broker traffic is TLS. One wildcard cert serves all three nodes;
+`messaging.ssl_search_id` names the `certificates` bag item holding it
+(default `wildcard`). Production runs the tier under `bak.osuosl.org`,
+which the standard wildcard does **not** cover, so it uses its own
+`*.bak.osuosl.org` cert item (see
+[Production deployment](#production-deployment-bringing-the-tier-online)).
 
 - **Broker:** RabbitMQ TLS listener on **5671** (AMQPS) via
   `rabbitmq.conf` `ssl_options` — certfile/keyfile from the wildcard
@@ -232,25 +364,26 @@ covers `mq1`/`mq2`/`mq3.<domain>`, so one cert serves all three nodes.
   endpoint port is **5671** — the `openstack_transport_url` helper
   switches the port when a new `messaging.tls` flag is set (folds into
   the vhost change, cookbook change 1).
-- **Migration:** keep 5672 (plaintext) open during the per-cloud
-  cutovers, then **disable the plaintext listener** (`listeners.tcp =
-  none`) once all three clouds are on 5671. Tier firewall: open 5671,
-  close 5672 at the end.
+- **Migration:** every cloud connects over TLS from its cutover, so the
+  tier runs `tls_only` (`listeners.tcp = none`) from day one — 5672 is
+  never offered.
 
 ### Monitoring (Nagios + Prometheus)
 
 - **Prometheus:** RabbitMQ 4.2 ships the built-in `rabbitmq_prometheus`
-  plugin — scrape `/metrics` on **15692** of all 3 nodes (+ node_exporter
-  for disk / fsync latency). Alert on: memory/disk-free alarms
+  plugin (chef-enabled by default); the `rabbitmq` scrape job in
+  `osl-prometheus::server` reads `/metrics` on **15692** of all 3 nodes
+  (+ node_exporter for disk / fsync latency). Alert on: memory/disk-free alarms
   (`rabbitmq_alarms_*`); cluster size < 3 nodes; **any quorum queue
   without an online majority / no leader** (the failure this design
   exists to survive); queue depth not draining
   (`rabbitmq_queue_messages_ready`); FDs near limit; connection-count
   spikes; publish-confirm latency (fsync proxy).
-- **Nagios (NRPE, via the `osl-openstack::mon` pattern):** per-node
-  `rabbitmq-diagnostics` checks — `ping`/`check_running`, `check_alarms`,
-  `cluster_status` (expect 3 nodes) — plus a TCP check on **5671**. Page
-  on node down, alarm set, or < 3 members.
+- **Nagios (NRPE, chef-managed):** `osl-openstack::mon` on `node_type`
+  `messaging` installs per-node checks — `check_rabbitmq_running`,
+  `check_rabbitmq_alarms`, `check_rabbitmq_cluster` (expect 3 running
+  members, from `cmr_target_group_size`), and `check_rabbitmq_listener`
+  (5671). Page on node down, alarm set, or < 3 members.
 - This is the concrete form of the blast-radius mitigation: since one
   incident hits all three clouds, the quorum-loss and alarm checks must
   **page**, not just dashboard.
@@ -369,8 +502,9 @@ remain on 3 distinct hosts after any migration.
    Trade-off to manage: whichever cloud goes last sits on the fragile
    embedded 2-node broker the longest, so keep the gaps between cutovers
    short.
-6. **TLS:** yes — TLS on **5671** using the existing wildcard cert; plain
-   5672 disabled after all clouds migrate. See
+6. **TLS:** yes — TLS on **5671**, cert selected by
+   `messaging.ssl_search_id` (prod: `*.bak.osuosl.org`); plaintext 5672
+   never offered (`tls_only`). See
    [Security & monitoring](#security--monitoring).
 7. **Monitoring:** Nagios (NRPE `rabbitmq-diagnostics` checks) +
    Prometheus (`rabbitmq_prometheus` on 15692), paging on quorum loss /
@@ -381,13 +515,8 @@ remain on 3 distinct hosts after any migration.
 
 ## Open items before build
 
-TLS, monitoring, secrets, migration order, and the EL10 repo arm are now
-decided/done (see Decisions, Security & monitoring, cookbook change 7).
-Remaining:
-- **EL10 in the test matrix.** Unit/integration platforms are EL8/EL9
-  only; add an AlmaLinux-10 platform so the `rabbitmq-4` repo arm and a
-  4.2 tier are exercised in CI (part of change 6).
-- **osl-firewall:** add 5671 + 15692 to the `rabbitmq_mgt` named port.
-- **Build the tier code:** `messaging.vhost` + `messaging.tls` in the
-  helper/templates, vhost-aware tier provisioning, drop `ops_messaging`
-  from controllers (changes 1-3, 6).
+All done: EL10 is in the test matrix (the `messaging_tier` kitchen suite
+and the multi-node terraform env), osl-firewall ships 5671/15692 in
+`rabbitmq_mgt`, and the tier code (changes 1-3, 6) is implemented and
+verified in the multi-node env. Production build-out steps:
+[Production deployment](#production-deployment-bringing-the-tier-online).

--- a/files/default/check_rabbitmq_cluster
+++ b/files/default/check_rabbitmq_cluster
@@ -1,0 +1,19 @@
+#!/bin/bash
+# NRPE check: CRITICAL when running RabbitMQ cluster members < expected.
+expected="${1:?usage: check_rabbitmq_cluster <expected_nodes>}"
+
+running=$(sudo /usr/sbin/rabbitmqctl -q cluster_status --formatter json 2>/dev/null |
+  /usr/bin/python3 -c 'import json,sys; print(len(json.load(sys.stdin)["running_nodes"]))' 2>/dev/null)
+
+if [ -z "$running" ]; then
+  echo 'RABBITMQ CLUSTER UNKNOWN: unable to read cluster_status'
+  exit 3
+fi
+
+if [ "$running" -lt "$expected" ]; then
+  echo "RABBITMQ CLUSTER CRITICAL: ${running}/${expected} nodes running"
+  exit 2
+fi
+
+echo "RABBITMQ CLUSTER OK: ${running}/${expected} nodes running"
+exit 0

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -52,12 +52,16 @@ suites:
     attributes:
       osl-openstack:
         databag_item: messaging_tier
+        node_type: messaging
     run_list:
       - role[openstack_tk]
       - recipe[osl-openstack::ops_messaging]
+      - recipe[osl-openstack::mon]
     verifier:
       inspec_tests:
         - test/integration/messaging_tier
+      inputs:
+        nrpe_checks: true
   - name: identity
     excludes:
       - almalinux-10

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -56,6 +56,11 @@ module OSLOpenstack
         cmd.stdout.match?(/^#{Regexp.escape(vhost)}\s*$/)
       end
 
+      def openstack_rabbitmq_plugin?(plugin)
+        cmd = shell_out!('rabbitmq-plugins -q list -e -m')
+        cmd.stdout.match?(/^#{Regexp.escape(plugin)}$/)
+      end
+
       # Messaging SIG selects version by subdir: EL8/9 use rabbitmq-38
       # (3.9.x), EL10 only ships rabbitmq-4 (4.x).
       def openstack_rabbitmq_repo

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -20,7 +20,6 @@
 include_recipe 'osl-nrpe'
 
 s = os_secrets
-cluster = s['database_server']['suffix']
 
 # Increase load threshold on openpower nodes (double the default values)
 if node['kernel']['machine'] == 'ppc64le'
@@ -88,7 +87,7 @@ if node['osl-openstack']['node_type'] == 'controller'
   end
 
   file '/usr/local/etc/os_cluster' do
-    content "export OS_CLUSTER=#{cluster}\n"
+    content "export OS_CLUSTER=#{s['database_server']['suffix']}\n"
   end
 
   chef_gem 'prometheus_reporter' do
@@ -107,5 +106,52 @@ if node['osl-openstack']['node_type'] == 'controller'
   cron 'openstack-prometheus' do
     command '/usr/local/libexec/openstack-prometheus'
     minute '*/10'
+  end
+end
+
+# Shared RabbitMQ messaging tier nodes.
+if node['osl-openstack']['node_type'] == 'messaging'
+  m = s['messaging']
+  listen_port = m['tls'] ? 5671 : 5672
+
+  # check_rabbitmq_cluster parses cluster_status JSON with python3.
+  package 'python3'
+
+  # rabbitmq-diagnostics/rabbitmqctl need the Erlang cookie (root).
+  node.default['authorization']['sudo']['include_sudoers_d'] = true
+  %w(nagios nrpe).each do |u|
+    sudo "check_rabbitmq-#{u}" do
+      user u
+      runas 'root'
+      nopasswd true
+      commands %w(
+        /usr/sbin/rabbitmq-diagnostics
+        /usr/sbin/rabbitmqctl
+      )
+    end
+  end
+
+  cookbook_file "#{node['nrpe']['plugin_dir']}/check_rabbitmq_cluster" do
+    mode '755'
+  end
+
+  nrpe_check 'check_rabbitmq_running' do
+    command 'sudo /usr/sbin/rabbitmq-diagnostics'
+    parameters '-q check_running'
+  end
+
+  nrpe_check 'check_rabbitmq_alarms' do
+    command 'sudo /usr/sbin/rabbitmq-diagnostics'
+    parameters '-q check_alarms'
+  end
+
+  nrpe_check 'check_rabbitmq_cluster' do
+    command "#{node['nrpe']['plugin_dir']}/check_rabbitmq_cluster"
+    parameters((m['cmr_target_group_size'] || 3).to_s)
+  end
+
+  nrpe_check 'check_rabbitmq_listener' do
+    command 'sudo /usr/sbin/rabbitmq-diagnostics'
+    parameters "-q check_port_listener #{listen_port}"
   end
 end

--- a/recipes/ops_messaging.rb
+++ b/recipes/ops_messaging.rb
@@ -25,6 +25,7 @@ osl_openstack_messaging 'default' do
   primary_node s['primary_node'] if s['primary_node']
   vhosts s['vhosts'] if s['vhosts']
   cmr_target_group_size s['cmr_target_group_size'] if s['cmr_target_group_size']
+  plugins s['plugins'] if s['plugins']
   if s['tls']
     tls true
     tls_only true if s['tls_only']

--- a/resources/messaging.rb
+++ b/resources/messaging.rb
@@ -23,6 +23,9 @@ property :tls_only, [true, false], default: false
 # up to this size.
 property :cmr_target_group_size, Integer
 
+# RabbitMQ plugins to enable (management UI + prometheus metrics).
+property :plugins, Array, default: %w(rabbitmq_management rabbitmq_prometheus)
+
 action :create do
   # rabbitmq-server comes from the Messaging SIG repo below, not the RDO
   # repos (no EL10 build), so we don't pull osl_repos_openstack here -
@@ -140,6 +143,14 @@ action :create do
             })
     unit_name 'rabbitmq-server.service'
     notifies :restart, 'service[rabbitmq-server]'
+  end
+
+  # Hot-enables on the running broker; no restart needed.
+  new_resource.plugins.each do |plugin|
+    execute "rabbitmq: enable plugin #{plugin}" do
+      command "rabbitmq-plugins enable #{plugin}"
+      not_if { openstack_rabbitmq_plugin?(plugin) }
+    end
   end
 
   execute "rabbitmq: add user #{new_resource.user}" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -289,6 +289,11 @@ shared_context 'common_stubs' do
     stubs_for_resource('execute[rabbitmq: set permissions openstack]') do |resource|
       allow(resource).to receive_shell_out('rabbitmqctl -q list_permissions')
     end
+    %w(rabbitmq_management rabbitmq_prometheus).each do |plugin|
+      stubs_for_resource("execute[rabbitmq: enable plugin #{plugin}]") do |resource|
+        allow(resource).to receive_shell_out('rabbitmq-plugins -q list -e -m')
+      end
+    end
     allow(File).to receive(:read).and_call_original
     allow(File).to receive(:read).with('/etc/ceph/ceph.conf').and_return('fsid = 8102bb29-f48b-4f6e-81d7-4c59d80ec6b8')
     allow(File).to receive(:readlines).and_call_original

--- a/spec/unit/recipes/mon_spec.rb
+++ b/spec/unit/recipes/mon_spec.rb
@@ -1,7 +1,8 @@
 require_relative '../../spec_helper'
 
 describe 'osl-openstack::mon' do
-  ALL_PLATFORMS.each do |pltfrm|
+  # EL10: the shared messaging tier is the only thing running there.
+  [*ALL_PLATFORMS, ALMA_10].each do |pltfrm|
     context "#{pltfrm[:platform]} #{pltfrm[:version]}" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(pltfrm).converge(described_recipe)
@@ -131,6 +132,77 @@ describe 'osl-openstack::mon' do
           it "passes the api_listen_ip to #{name}" do
             expect(chef_run).to add_nrpe_check(name).with(parameters: params)
           end
+        end
+      end
+
+      context 'messaging' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm) do |node|
+            node.normal['osl-openstack']['node_type'] = 'messaging'
+          end.converge(described_recipe)
+        end
+
+        it { is_expected.to_not install_package 'nagios-plugins-http' }
+        it { is_expected.to install_package 'python3' }
+
+        %w(nagios nrpe).each do |u|
+          it do
+            is_expected.to create_sudo("check_rabbitmq-#{u}").with(
+              user: [u],
+              runas: 'root',
+              nopasswd: true,
+              commands: %w(/usr/sbin/rabbitmq-diagnostics /usr/sbin/rabbitmqctl)
+            )
+          end
+        end
+
+        it { is_expected.to create_cookbook_file('/usr/lib64/nagios/plugins/check_rabbitmq_cluster').with(mode: '755') }
+
+        it do
+          is_expected.to add_nrpe_check('check_rabbitmq_running').with(
+            command: 'sudo /usr/sbin/rabbitmq-diagnostics',
+            parameters: '-q check_running'
+          )
+        end
+        it do
+          is_expected.to add_nrpe_check('check_rabbitmq_alarms').with(
+            command: 'sudo /usr/sbin/rabbitmq-diagnostics',
+            parameters: '-q check_alarms'
+          )
+        end
+        it do
+          is_expected.to add_nrpe_check('check_rabbitmq_cluster').with(
+            command: '/usr/lib64/nagios/plugins/check_rabbitmq_cluster',
+            parameters: '3'
+          )
+        end
+        it do
+          is_expected.to add_nrpe_check('check_rabbitmq_listener').with(
+            command: 'sudo /usr/sbin/rabbitmq-diagnostics',
+            parameters: '-q check_port_listener 5672'
+          )
+        end
+
+        context 'TLS tier' do
+          cached(:chef_run) do
+            ChefSpec::SoloRunner.new(pltfrm) do |node|
+              node.normal['osl-openstack']['node_type'] = 'messaging'
+            end.converge(described_recipe)
+          end
+
+          before do
+            stub_data_bag_item('openstack', 'x86').and_return(
+              openstack_secrets_stub.merge(
+                'messaging' => openstack_secrets_stub['messaging'].merge(
+                  'tls' => true,
+                  'cmr_target_group_size' => 3
+                )
+              )
+            )
+          end
+
+          it { is_expected.to add_nrpe_check('check_rabbitmq_listener').with(parameters: '-q check_port_listener 5671') }
+          it { is_expected.to add_nrpe_check('check_rabbitmq_cluster').with(parameters: '3') }
         end
       end
 

--- a/spec/unit/recipes/ops_messaging_spec.rb
+++ b/spec/unit/recipes/ops_messaging_spec.rb
@@ -40,6 +40,13 @@ describe 'osl-openstack::ops_messaging' do
 
       it { is_expected.to enable_service 'rabbitmq-server' }
       it { is_expected.to start_service 'rabbitmq-server' }
+      %w(rabbitmq_management rabbitmq_prometheus).each do |plugin|
+        it do
+          is_expected.to run_execute("rabbitmq: enable plugin #{plugin}").with(
+            command: "rabbitmq-plugins enable #{plugin}"
+          )
+        end
+      end
       case pltfrm
       when ALMA_8
         it do
@@ -147,6 +154,27 @@ describe 'osl-openstack::ops_messaging' do
         it { is_expected.to render_file('/etc/rabbitmq/rabbitmq.conf').with_content('ssl_options.certfile = /etc/rabbitmq/ssl/certs/cert.pem') }
         it { is_expected.to render_file('/etc/rabbitmq/rabbitmq.conf').with_content(/^listeners.tcp = none$/) }
         it { is_expected.to render_file('/etc/rabbitmq/rabbitmq.conf').with_content('target_group_size = 3') }
+      end
+
+      context 'custom ssl_search_id' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm.dup.merge(
+            step_into: %w(osl_openstack_messaging)
+          )).converge(described_recipe)
+        end
+
+        before do
+          stub_data_bag_item('openstack', 'x86').and_return(
+            openstack_secrets_stub.merge(
+              'messaging' => openstack_secrets_stub['messaging'].merge(
+                'tls' => true,
+                'ssl_search_id' => 'wildcard-bak'
+              )
+            )
+          )
+        end
+
+        it { is_expected.to create_certificate_manage('wildcard-rabbitmq').with(search_id: 'wildcard-bak') }
       end
     end
   end

--- a/test/integration/messaging_tier/controls/messaging_tier.rb
+++ b/test/integration/messaging_tier/controls/messaging_tier.rb
@@ -1,11 +1,13 @@
 # Broker coverage for the shared messaging tier. Defaults cover the
 # single-node kitchen suite; the multi-node env passes inputs
 # (vhost/vhost_user/cluster_size/cmr_target_group_size) to also assert
-# clustering + CMR.
+# clustering + CMR. nrpe_checks is set only by the single-node suite
+# (the multi-node mq systems don't run osl-openstack::mon).
 vhost = input('vhost', value: 'tier-test')
 vhost_user = input('vhost_user', value: 'tier')
 cluster_size = input('cluster_size', value: 1)
 cmr_target_group_size = input('cmr_target_group_size', value: 0)
+nrpe_checks = input('nrpe_checks', value: false)
 
 control 'messaging_tier' do
   describe service('rabbitmq-server') do
@@ -53,6 +55,14 @@ control 'messaging_tier' do
     end
   end
 
+  # Management (15672) + prometheus (15692) plugins.
+  describe port(15672) do
+    it { should be_listening }
+  end
+  describe port(15692) do
+    it { should be_listening }
+  end
+
   # Per-cloud vhost + user with vhost-scoped permissions.
   describe command('rabbitmqctl -q list_vhosts') do
     its('stdout') { should match(/^#{Regexp.escape(vhost)}$/) }
@@ -68,6 +78,41 @@ control 'messaging_tier' do
     describe command("rabbitmqctl -q list_queues -p #{vhost} type") do
       its('exit_status') { should eq 0 }
       its('stdout') { should match(/^quorum$/) }
+    end
+  end
+
+  # NRPE checks from osl-openstack::mon, run exactly as NRPE would (as
+  # the nrpe user, through its sudo grant).
+  if nrpe_checks
+    %w(
+      check_rabbitmq_running
+      check_rabbitmq_alarms
+      check_rabbitmq_cluster
+      check_rabbitmq_listener
+    ).each do |chk|
+      describe file("/etc/nagios/nrpe.d/#{chk}.cfg") do
+        it { should exist }
+      end
+    end
+
+    %w(check_running check_alarms).each do |chk|
+      describe command("sudo -u nrpe sudo /usr/sbin/rabbitmq-diagnostics -q #{chk}") do
+        its('exit_status') { should eq 0 }
+      end
+    end
+    describe command('sudo -u nrpe sudo /usr/sbin/rabbitmq-diagnostics -q check_port_listener 5671') do
+      its('exit_status') { should eq 0 }
+    end
+
+    # The cluster plugin: OK at the real member count, CRITICAL when a
+    # member is missing (expected count + 1 can never be satisfied).
+    describe command("sudo -u nrpe /usr/lib64/nagios/plugins/check_rabbitmq_cluster #{cluster_size}") do
+      its('exit_status') { should eq 0 }
+      its('stdout') { should match(%r{OK: #{cluster_size}/#{cluster_size} nodes running}) }
+    end
+    describe command("sudo -u nrpe /usr/lib64/nagios/plugins/check_rabbitmq_cluster #{cluster_size + 1}") do
+      its('exit_status') { should eq 2 }
+      its('stdout') { should match(%r{CRITICAL: #{cluster_size}/#{cluster_size + 1} nodes running}) }
     end
   end
 end

--- a/test/integration/ops_messaging/controls/ops_messaging_spec.rb
+++ b/test/integration/ops_messaging/controls/ops_messaging_spec.rb
@@ -9,6 +9,14 @@ control 'ops_messaging' do
     its('protocols') { should include 'tcp' }
   end
 
+  # Management (15672) + prometheus (15692) plugins, enabled by default.
+  describe port 15672 do
+    it { should be_listening }
+  end
+  describe port 15692 do
+    it { should be_listening }
+  end
+
   describe iptables do
     it { should have_rule '-A amqp -p tcp -m tcp --dport 5672 -j osl_only' }
     it { should have_rule '-A rabbitmq_mgt -p tcp -m tcp --dport 15672 -j osl_only' }


### PR DESCRIPTION
- docs: concrete build-out steps (VMs/DNS under bak.osuosl.org, data bag,
  role, bootstrap + knife node edit + cinc-client per node mq1-first,
  verification, monitoring, failover validation); refresh stale status
- messaging.ssl_search_id selects the cert bag item (prod tier needs a
  *.bak.osuosl.org cert; default wildcard) - spec coverage for override
- Enable rabbitmq_management + rabbitmq_prometheus by default on all
  brokers (messaging.plugins overrides); guarded hot-enable, idempotent
- mon: NRPE checks for node_type=messaging (check_running, check_alarms,
  cluster size via new check_rabbitmq_cluster plugin, TLS listener) with
  sudo grants for nagios/nrpe; messaging_tier kitchen suite runs mon and
  its inspec exercises the checks as the nrpe user (nrpe_checks input)
- tls_only from day one (clouds only ever connect over TLS)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
