### PR TITLE
RabbitMQ: management UI login + accurate cluster-join reporting

### DIFF
--- a/docs/SHARED_MESSAGING_TIER.md
+++ b/docs/SHARED_MESSAGING_TIER.md
@@ -493,6 +493,9 @@ which the standard wildcard does **not** cover, so it uses its own
   `check_rabbitmq_alarms`, `check_rabbitmq_cluster` (expect 3 running
   members, from `cmr_target_group_size`), and `check_rabbitmq_listener`
   (5671). Page on node down, alarm set, or < 3 members.
+- **Management UI:** `http://mqN.bak.osuosl.org:15672` (OSL-only). Log
+  in as `messaging.user` — chef tags it `administrator`; the per-cloud
+  vhost users stay untagged (AMQP-only).
 - This is the concrete form of the blast-radius mitigation: since one
   incident hits all three clouds, the quorum-loss and alarm checks must
   **page**, not just dashboard.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -84,34 +84,28 @@ module OSLOpenstack
       # the brokers are isolated and OpenStack RPC reply queues become
       # undeliverable when request and reply go through different nodes.
       def openstack_rabbitmq_join_cluster(primary_node_name)
-        # Extract the primary's short hostname from "rabbit@<host>.<domain>"
-        # and compare exactly to node['hostname'] - substring matching
-        # would conflate "controller" with "controller2".
+        Chef::Log.info("Joining RabbitMQ cluster with primary '#{primary_node_name}'.")
+        shell_out!('rabbitmqctl stop_app')
+        shell_out!("rabbitmqctl join_cluster #{primary_node_name}")
+        shell_out!('rabbitmqctl start_app')
+      rescue Mixlib::ShellOut::ShellCommandFailed => e
+        Chef::Log.error("RabbitMQ join_cluster failed: #{e.message}")
+        shell_out('rabbitmqctl start_app')
+        raise 'Failed to join RabbitMQ cluster; see chef logs.'
+      end
+
+      # True when this node should join the primary's cluster: it isn't
+      # the primary itself and isn't already a member.
+      def openstack_rabbitmq_join_needed?(primary_node_name)
+        # Compare short hostnames exactly ("rabbit@mq1.bak.osuosl.org" ->
+        # "mq1"); substring matching would conflate mq1 with mq10.
         primary_short_hostname = primary_node_name.split('@', 2).last.split('.', 2).first
-        if primary_short_hostname == node['hostname']
-          Chef::Log.info("This node IS the RabbitMQ primary ('#{primary_node_name}'). No join needed.")
-          return false
-        end
-        # rabbitmqctl 3.8 doesn't accept --format json on cluster_status.
-        # Parse the plain text output - if the primary's node name shows
-        # up at all, we're already clustered with it.
+        return false if primary_short_hostname == node['hostname']
+        # rabbitmqctl 3.8 doesn't accept --format json on cluster_status;
+        # if the primary's node name shows up, we're already clustered.
         cluster_status = shell_out('rabbitmqctl cluster_status')
         cluster_status.error!
-        if cluster_status.stdout.include?(primary_node_name)
-          Chef::Log.info("Already clustered with '#{primary_node_name}'. Skipping.")
-          return false
-        end
-        Chef::Log.info("Joining RabbitMQ cluster with primary '#{primary_node_name}'.")
-        begin
-          shell_out!('rabbitmqctl stop_app')
-          shell_out!("rabbitmqctl join_cluster #{primary_node_name}")
-          shell_out!('rabbitmqctl start_app')
-          true
-        rescue Mixlib::ShellOut::ShellCommandFailed => e
-          Chef::Log.error("RabbitMQ join_cluster failed: #{e.message}")
-          shell_out('rabbitmqctl start_app')
-          raise 'Failed to join RabbitMQ cluster; see chef logs.'
-        end
+        !cluster_status.stdout.include?(primary_node_name)
       end
 
       def openstack_services

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -61,6 +61,11 @@ module OSLOpenstack
         cmd.stdout.match?(/^#{Regexp.escape(plugin)}$/)
       end
 
+      def openstack_rabbitmq_user_tag?(user, tag)
+        cmd = shell_out!('rabbitmqctl -q list_users')
+        cmd.stdout.match?(/^#{Regexp.escape(user)}\s+\[[^\]]*#{Regexp.escape(tag)}/)
+      end
+
       # Messaging SIG selects version by subdir: EL8/9 use rabbitmq-38
       # (3.9.x), EL10 only ships rabbitmq-4 (4.x).
       def openstack_rabbitmq_repo

--- a/resources/messaging.rb
+++ b/resources/messaging.rb
@@ -172,9 +172,13 @@ action :create do
     not_if { openstack_rabbitmq_user_tag?(new_resource.user, 'administrator') }
   end
 
-  converge_by "join RabbitMQ cluster with primary #{new_resource.primary_node}" do
-    openstack_rabbitmq_join_cluster(new_resource.primary_node)
-  end if new_resource.primary_node
+  # Gate converge_by on the predicate so steady-state runs (and the
+  # primary itself) report nothing instead of a phantom join every run.
+  if new_resource.primary_node && openstack_rabbitmq_join_needed?(new_resource.primary_node)
+    converge_by "join RabbitMQ cluster with primary #{new_resource.primary_node}" do
+      openstack_rabbitmq_join_cluster(new_resource.primary_node)
+    end
+  end
 
   # Per-cloud vhosts/users. After the join so metadata replicates; not_if
   # guards keep secondaries idempotent (they exist there post-join).

--- a/resources/messaging.rb
+++ b/resources/messaging.rb
@@ -166,6 +166,12 @@ action :create do
     not_if { openstack_rabbitmq_permissions?(new_resource.user) }
   end
 
+  # administrator tag = management UI (15672) login for the main user.
+  execute "rabbitmq: set user tags #{new_resource.user}" do
+    command "rabbitmqctl set_user_tags #{new_resource.user} administrator"
+    not_if { openstack_rabbitmq_user_tag?(new_resource.user, 'administrator') }
+  end
+
   converge_by "join RabbitMQ cluster with primary #{new_resource.primary_node}" do
     openstack_rabbitmq_join_cluster(new_resource.primary_node)
   end if new_resource.primary_node

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -289,6 +289,9 @@ shared_context 'common_stubs' do
     stubs_for_resource('execute[rabbitmq: set permissions openstack]') do |resource|
       allow(resource).to receive_shell_out('rabbitmqctl -q list_permissions')
     end
+    stubs_for_resource('execute[rabbitmq: set user tags openstack]') do |resource|
+      allow(resource).to receive_shell_out('rabbitmqctl -q list_users')
+    end
     %w(rabbitmq_management rabbitmq_prometheus).each do |plugin|
       stubs_for_resource("execute[rabbitmq: enable plugin #{plugin}]") do |resource|
         allow(resource).to receive_shell_out('rabbitmq-plugins -q list -e -m')

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -137,6 +137,40 @@ describe OSLOpenstack::Cookbook::Helpers do
     end
   end
 
+  describe '#openstack_rabbitmq_join_needed?' do
+    let(:primary) { 'rabbit@mq1.bak.osuosl.org' }
+
+    def stub_cluster_status(stdout)
+      status = double(stdout: stdout)
+      allow(status).to receive(:error!)
+      allow(helper).to receive(:shell_out).with('rabbitmqctl cluster_status').and_return(status)
+    end
+
+    it 'is false on the primary itself (multi-label domain -> short hostname)' do
+      allow(helper).to receive(:node).and_return('hostname' => 'mq1')
+      expect(helper).to_not receive(:shell_out)
+      expect(helper.openstack_rabbitmq_join_needed?(primary)).to be false
+    end
+
+    it 'is false on a secondary already clustered with the primary' do
+      allow(helper).to receive(:node).and_return('hostname' => 'mq2')
+      stub_cluster_status("Running Nodes\n\nrabbit@mq1.bak.osuosl.org\nrabbit@mq2.bak.osuosl.org\n")
+      expect(helper.openstack_rabbitmq_join_needed?(primary)).to be false
+    end
+
+    it 'is true on an unclustered secondary' do
+      allow(helper).to receive(:node).and_return('hostname' => 'mq2')
+      stub_cluster_status("Running Nodes\n\nrabbit@mq2.bak.osuosl.org\n")
+      expect(helper.openstack_rabbitmq_join_needed?(primary)).to be true
+    end
+
+    it 'does not conflate the primary hostname with one it prefixes' do
+      allow(helper).to receive(:node).and_return('hostname' => 'mq10')
+      stub_cluster_status("Running Nodes\n\nrabbit@mq10.bak.osuosl.org\n")
+      expect(helper.openstack_rabbitmq_join_needed?(primary)).to be true
+    end
+  end
+
   describe '#openstack_transport_url' do
     let(:messaging) do
       { 'user' => 'openstack', 'pass' => 's3cret',

--- a/spec/unit/recipes/ops_messaging_spec.rb
+++ b/spec/unit/recipes/ops_messaging_spec.rb
@@ -91,6 +91,12 @@ describe 'osl-openstack::ops_messaging' do
         )
       end
 
+      it do
+        is_expected.to run_execute('rabbitmq: set user tags openstack').with(
+          command: 'rabbitmqctl set_user_tags openstack administrator'
+        )
+      end
+
       context 'user created' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(pltfrm.dup.merge(
@@ -101,10 +107,12 @@ describe 'osl-openstack::ops_messaging' do
         before do
           allow_any_instance_of(OSLOpenstack::Cookbook::Helpers).to receive(:openstack_rabbitmq_user?).and_return(true)
           allow_any_instance_of(OSLOpenstack::Cookbook::Helpers).to receive(:openstack_rabbitmq_permissions?).and_return(true)
+          allow_any_instance_of(OSLOpenstack::Cookbook::Helpers).to receive(:openstack_rabbitmq_user_tag?).and_return(true)
         end
 
         it { is_expected.to nothing_execute('rabbitmq: add user openstack') }
         it { is_expected.to nothing_execute('rabbitmq: set permissions openstack') }
+        it { is_expected.to nothing_execute('rabbitmq: set user tags openstack') }
       end
 
       context 'shared messaging tier (vhosts + TLS + CMR)' do

--- a/test/integration/messaging_tier/controls/messaging_tier.rb
+++ b/test/integration/messaging_tier/controls/messaging_tier.rb
@@ -63,6 +63,11 @@ control 'messaging_tier' do
     it { should be_listening }
   end
 
+  # Main user tagged administrator for the management UI.
+  describe command('rabbitmqctl -q list_users') do
+    its('stdout') { should match(/^openstack\s+\[administrator\]/) }
+  end
+
   # Per-cloud vhost + user with vhost-scoped permissions.
   describe command('rabbitmqctl -q list_vhosts') do
     its('stdout') { should match(/^#{Regexp.escape(vhost)}$/) }

--- a/test/integration/ops_messaging/controls/ops_messaging_spec.rb
+++ b/test/integration/ops_messaging/controls/ops_messaging_spec.rb
@@ -28,7 +28,7 @@ control 'ops_messaging' do
   end
 
   describe command('rabbitmqctl -q list_users') do
-    its('stdout') { should match(/openstack.*\[\]/) }
+    its('stdout') { should match(/openstack.*\[administrator\]/) }
   end
 
   describe command 'systemctl cat rabbitmq-server' do


### PR DESCRIPTION
## Summary
- Tag the main rabbitmq user (`messaging.user`) `administrator` so the management UI (15672) accepts a login — users were created tagless (AMQP-only), so nothing could sign in. Guarded via a new `openstack_rabbitmq_user_tag?` helper; per-cloud vhost users deliberately stay untagged.
- Gate the cluster-join `converge_by` on a new `openstack_rabbitmq_join_needed?` predicate. Previously every converge on every broker (including the primary) reported "join RabbitMQ cluster" as an executed action; steady-state runs now report nothing and the join line only appears on a real join.

## Testing
- cookstyle clean; full unit suite green (1371 examples, 0 failures)
- New helper specs pin the multi-label domain parsing (`rabbit@mq1.bak.osuosl.org`): primary skips without shelling out, clustered secondary skips, unclustered secondary joins, `mq1` != `mq10`
- inspec asserts the `administrator` tag on both the ops_messaging and messaging_tier suites
- Applied manually to the prod tier (`set_user_tags openstack administrator`) — UI login confirmed working; chef now converges to the same state

🤖 Generated with [Claude Code](https://claude.com/claude-code)