### PR TITLE
Disable the ceilometer event pipeline

### DIFF
--- a/spec/unit/recipes/telemetry_controller_spec.rb
+++ b/spec/unit/recipes/telemetry_controller_spec.rb
@@ -48,6 +48,12 @@ describe 'osl-openstack::telemetry_controller' do
           }
         )
       end
+      # Meter pipeline only - no event store is deployed, so the default
+      # meter,event set would fill event.sample with unconsumed messages.
+      it do
+        is_expected.to render_file('/etc/ceilometer/ceilometer.conf')
+          .with_content(/^\[notification\]$.*^pipelines = meter$/m)
+      end
       it do
         is_expected.to create_template('/etc/ceilometer/pipeline.yaml').with(
           owner: 'ceilometer',

--- a/templates/ceilometer.conf.erb
+++ b/templates/ceilometer.conf.erb
@@ -9,6 +9,11 @@ memcache_servers = <%= @memcached_endpoint %>
 enabled = true
 backend = dogpile.cache.memcached
 
+[notification]
+# No event store (panko) is deployed; the default meter,event set would
+# fill event.sample with messages nothing consumes.
+pipelines = meter
+
 <% if @rabbit_quorum_queue || @rabbit_tls -%>
 [oslo_messaging_rabbit]
 <% if @rabbit_quorum_queue -%>

--- a/test/integration/telemetry_controller/controls/telemetry_spec.rb
+++ b/test/integration/telemetry_controller/controls/telemetry_spec.rb
@@ -39,6 +39,7 @@ control 'telemetry-controller' do
   describe ini('/etc/ceilometer/ceilometer.conf') do
     its('DEFAULT.transport_url') { should match(%r{^rabbit://openstack:openstack@#{Regexp.escape(messaging_host)}:#{messaging_port}}) }
     its('cache.memcache_servers') { should match(/#{Regexp.escape(memcached_host)}:11211/) }
+    its('notification.pipelines') { should cmp 'meter' }
     its('service_credentials.auth_url') { should cmp 'https://controller.testing.osuosl.org:5000/v3' }
     its('service_credentials.password') { should cmp 'ceilometer' }
   end


### PR DESCRIPTION
- No event store (panko) is deployed, so the default meter,event
  pipeline set publishes events nothing consumes; on the quorum-queue
  tier event.sample is durable and replicated x3, growing unbounded
- [notification] pipelines = meter keeps only the meter pipeline
- unit + inspec coverage

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
