### PR TITLE
Add valkey + sentinel coordination tier on the mq nodes

### DIFF
--- a/docs/COORDINATION_TIER.md
+++ b/docs/COORDINATION_TIER.md
@@ -1,0 +1,245 @@
+# Design: shared valkey coordination (tooz lock) tier
+
+Status: tier implemented in the cookbook (`ops_coordination` on the mq
+nodes); the client side (cinder pointing tooz at it) lands as a
+follow-up change. Runs on the same three mq nodes as the
+[shared RabbitMQ messaging tier](SHARED_MESSAGING_TIER.md).
+
+## Motivation
+
+Cinder volume attach failed with HTTP 500 on all three clusters. The
+`attachment_update` API takes a tooz lock named
+`cinder-attachment_update-<volume_uuid>-<connector_host>`, which always
+exceeds 64 characters, and the tooz mysql driver passes lock names raw
+into `GET_LOCK()`, which MySQL/Percona 8.0 hard-rejects (error 4163).
+On top of that, `GET_LOCK` locks are local to the server a session is
+connected to and are not Galera-replicated, so the mysql driver never
+provided real cross-node exclusion behind the HA frontend.
+
+The follow-up cinder change drops the mysql `backend_url` and points
+tooz at this tier via the `redis://` driver (valkey is
+protocol-compatible with redis), restoring working distributed locks.
+
+Rejected alternatives: etcd (fine, but valkey is preferred for reuse
+potential and operator familiarity); patching the tooz mysql driver to
+hash long names (carries a local patch and keeps the Galera locality
+caveat); per-cluster valkey processes on separate ports (more chef
+surface for negligible benefit at this load).
+
+## Topology
+
+- One `valkey-server` per mq node: mq1 primary, mq2/mq3 replicas
+  (`replicaof`), all requiring the shared password.
+- `valkey-sentinel` on all three nodes monitoring service `oslocks`,
+  quorum 2. Sentinel handles primary failover; clients discover the
+  current primary through sentinel on 26379.
+- One shared instance serves all three clouds, separated by redis db
+  index: x86 db 0, arm db 1, ppc db 2. tooz additionally namespaces its
+  keys under `_tooz`.
+- Packages from EL10 AppStream: the single `valkey` package ships both
+  `valkey.service` and `valkey-sentinel.service` with configs under
+  `/etc/valkey/`.
+- `maxmemory-policy noeviction` (an evicted lock key is a silently
+  released lock) and `appendonly yes` (held locks survive a restart).
+- `min-replicas-to-write 1` on the tier: a primary that loses both
+  replicas refuses writes, so a partitioned ex-primary cannot keep
+  granting locks the promoted side does not see.
+
+## Chef pieces
+
+- The valkey/sentinel mechanics (package, seed-once configs, services,
+  OSL-only firewall, operator tooling) live in the reusable
+  **osl-valkey** cookbook (`osl_valkey` + `osl_valkey_sentinel`
+  resources).
+- [resources/coordination.rb](../resources/coordination.rb): maps the
+  tier topology onto those resources: primary/replica from the data
+  bag `primary` vs the node's hostname, quorum from the `endpoint`
+  count, lock-service settings (noeviction, AOF,
+  `min-replicas-to-write 1` when clustered so an isolated ex-primary
+  goes read-only instead of granting locks the rest of the cluster
+  cannot see).
+- [recipes/ops_coordination.rb](../recipes/ops_coordination.rb): thin
+  wrapper reading the `coordination` block of the node's `openstack`
+  data bag item. Add it to the mq node run lists alongside
+  `ops_messaging`.
+
+### Seed-once configs (`config_version`)
+
+Both config files are rewritten by the daemons at runtime: sentinel
+persists its myid, config epoch, discovered replicas/sentinels and
+failover state; valkey persists its replication role when sentinel
+promotes or demotes it. A plain chef template would fight those
+rewrites and re-point a promoted primary back at the seeded topology on
+every converge.
+
+So chef seeds each file once and records
+`coordination.config_version` (default 1) in a marker file
+(`/etc/valkey/.valkey.conf.chef`, `/etc/valkey/.sentinel.conf.chef`).
+To push a config change: bump `config_version` in the data bag and
+converge. This re-renders both files from the template, restarts the
+services, and resets any runtime failover state back to the configured
+topology (mq1 primary), so treat a bump as a small maintenance action,
+not a routine converge.
+
+Known risks of the seed-once model:
+
+- **Template edits without a version bump apply only to future
+  seeds.** An existing node keeps its old config; a rebuilt node gets
+  the new one. Any template change must ship with a `config_version`
+  bump to reach the fleet.
+- **Drift is invisible to chef.** Manual edits (or anything else that
+  touches the files) are never detected or reverted. The NRPE checks
+  are the guard against the failure modes that matter (auth, eviction
+  policy, replication, quorum), not converge-time enforcement.
+- **A re-seed is topology-affecting.** If sentinel promoted mq2 in the
+  meantime, the bump demotes it back to replica-of-mq1 and restarts
+  everything; locks held across that window on the demoted primary can
+  be lost. Cinder tooz locks are short-lived, so the blast radius is a
+  racing attach/detach, but schedule bumps like a small maintenance.
+- **A stale ex-primary must not be re-seeded in isolation.** mq1
+  restored from an old snapshot and re-seeded as primary would serve
+  an empty/stale lock db while mq2/mq3 still follow the sentinel-
+  elected primary. Rebuild members without markers join per the seeded
+  topology; verify replication state afterwards.
+
+### Data bag schema
+
+The `coordination` block, in the tier's own bag item
+(`messaging_tier`) and, for the client keys, in each cloud's item:
+
+```json
+"coordination": {
+  "endpoint": ["mq1.bak.osuosl.org", "mq2.bak.osuosl.org", "mq3.bak.osuosl.org"],
+  "primary": "mq1.bak.osuosl.org",
+  "pass": "<openssl rand -hex 20>",
+  "db": 0
+}
+```
+
+- `endpoint`: all tier nodes; sizes the sentinel quorum ((N/2)+1) on
+  the tier and provides the sentinel fallback list to clients.
+- `primary`: initial primary; a node whose short hostname doesn't match
+  becomes a replica. Omit for a standalone single node (kitchen suite).
+- `pass`: valkey password (requirepass/masterauth, and the client
+  password). Keep it URL-safe (hex): it is embedded in `backend_url`.
+- `db`: client-side only; per-cloud database index (x86 0, arm 1,
+  ppc 2). The tier ignores it.
+- Optional: `service_name` (default `oslocks`), `down_after_ms`
+  (5000), `failover_timeout_ms` (60000), `config_version` (1).
+
+### Security
+
+valkey requires the password for every client. Sentinel could too
+(osl-valkey exposes `requirepass` for it), but this tier deliberately
+leaves it unset: tooz 2.10.1 (yoga, verified on all three clusters) has
+no way to send a sentinel password - its redis driver only passes the
+userinfo password to the elected primary - so a sentinel that demanded
+one would lock cinder out. That is a client limitation, not a sentinel
+one; if a future tooz gains support, set `requirepass` and drop the
+exception. Until then sentinel exposure is limited by the OSL-only
+firewall on 26379 (same trust level as the rabbitmq management ports).
+Sentinel authenticates itself to the monitored valkeys via `auth-pass`.
+
+## Production deployment
+
+The tier reuses the existing mq nodes, so this is a data bag edit plus
+a run list addition. Everything else (package, configs, firewall,
+services) is chef-managed.
+
+1. Generate the shared password (`openssl rand -hex 20`) and add the
+   `coordination` block (schema above, without `db`) to the
+   `messaging_tier` bag item:
+
+   ```bash
+   knife data bag edit openstack messaging_tier
+   ```
+
+2. Add the recipe to each mq node, converging mq1 (the primary) first
+   so replicas have something to sync from:
+
+   ```bash
+   # per node, mq1 first:
+   knife node run_list add mq1.bak.osuosl.org 'recipe[osl-openstack::ops_coordination]'
+   ssh mq1.bak.osuosl.org cinc-client
+   # verify (step 3 subset), then repeat for mq2, then mq3
+   ```
+
+3. Verify the tier. `valkey-status` (installed by osl-valkey) shows
+   sentinel's view plus live replication state of every member in one
+   shot; the raw commands are the fallback:
+
+   ```bash
+   valkey-status                                      # exit 0, all members healthy
+
+   # or by hand, on each node:
+   systemctl is-active valkey valkey-sentinel
+   valkey-cli ping                                    # NOAUTH error
+   valkey-cli -a "$PASS" --no-auth-warning ping       # PONG
+   valkey-cli -a "$PASS" --no-auth-warning info replication
+   valkey-cli -p 26379 sentinel ckquorum oslocks
+   ```
+
+4. Failover validation, before any cloud points at the tier: stop
+   valkey on mq1, confirm a replica is promoted within
+   `down-after-milliseconds` plus election time, then restart mq1 and
+   confirm it rejoins as a replica of the new primary:
+
+   ```bash
+   ssh mq1.bak.osuosl.org sudo systemctl stop valkey
+   # from mq2: watch the promotion
+   valkey-cli -p 26379 sentinel master oslocks   # ip flips off mq1
+   ssh mq1.bak.osuosl.org sudo systemctl start valkey
+   valkey-status                                 # mq1 back as a replica, link up
+   ```
+
+   That is the crash-style test. For planned maintenance on the
+   primary (patching, reboot), use `valkey-failover` instead: it
+   preflights replica ack, triggers a sentinel failover, and waits for
+   the switch, so the primary moves before you take the node down.
+
+   Note chef does not demote/promote anything at runtime; sentinel
+   owns the topology after the seed. A converge during or after a
+   failover is a no-op on the configs.
+
+## Client side (follow-up change)
+
+Each cloud's `cinder.conf` gets, via its data bag item's
+`coordination` block:
+
+```ini
+[coordination]
+backend_url = redis://:<pass>@mq1:26379?sentinel=oslocks&sentinel_fallback=mq2:26379&sentinel_fallback=mq3:26379&db=<N>
+```
+
+Controllers need `python3-redis` (in the yoga RDO repos, noarch, all
+arches). Rollout x86 first (it has the known-broken attach to verify
+against), then arm, then ppc. Verification per cloud: attach/detach
+smoke test on a scratch VM, stuck `reserved` attachments cleaned up,
+and lock keys visible during an attach:
+
+```bash
+valkey-cli -a "$PASS" --no-auth-warning -n <db> --scan --pattern '_tooz*'
+```
+
+## Monitoring
+
+NRPE (chef-managed, via `osl-openstack::mon` on `node_type: messaging`
+when the bag item has a `coordination` block):
+
+- `check_valkey`: authenticated PING (reads requirepass root-only via
+  the same sudo grant pattern as the rabbitmq checks)
+- `check_valkey_replication`: primary has all expected replicas
+  connected, or replica link is up (survives failovers; it checks the
+  current role, not the seeded one)
+- `check_valkey_sentinel`: `sentinel ckquorum` + all other members'
+  sentinels discovered (no auth needed)
+
+Remaining manual work mirrors the rabbitmq tier: Nagios server service
+definitions for the new checks. Page on ping/quorum failures; a lock
+service outage breaks volume attach on all three clouds at once.
+
+Prometheus: valkey has no built-in metrics endpoint, so this needs a
+`redis_exporter` deployment plus a scrape job for the mq nodes, both
+of which belong in the **osl-prometheus** cookbook (the
+`osl_prometheus_exporter` resource is the pattern). Follow-up there,
+not in this cookbook.

--- a/files/default/check_valkey
+++ b/files/default/check_valkey
@@ -1,0 +1,13 @@
+#!/bin/bash
+# NRPE check: valkey answers an authenticated PING. Reads requirepass
+# from valkey.conf (root-only), so this runs under sudo.
+pass=$(awk '/^requirepass /{gsub(/"/, "", $2); print $2}' /etc/valkey/valkey.conf)
+out=$(REDISCLI_AUTH="$pass" /usr/bin/valkey-cli ping 2>&1)
+
+if [ "$out" = "PONG" ]; then
+  echo 'VALKEY OK: PONG'
+  exit 0
+fi
+
+echo "VALKEY CRITICAL: ${out:-no reply}"
+exit 2

--- a/files/default/check_valkey_replication
+++ b/files/default/check_valkey_replication
@@ -1,0 +1,32 @@
+#!/bin/bash
+# NRPE check: this member is a primary with all expected replicas
+# connected, or a replica with its link up. Reads requirepass from
+# valkey.conf (root-only), so this runs under sudo.
+expected="${1:?usage: check_valkey_replication <cluster_size>}"
+pass=$(awk '/^requirepass /{gsub(/"/, "", $2); print $2}' /etc/valkey/valkey.conf)
+info=$(REDISCLI_AUTH="$pass" /usr/bin/valkey-cli info replication 2>/dev/null | tr -d '\r')
+
+role=$(awk -F: '/^role:/{print $2}' <<< "$info")
+case "$role" in
+  master)
+    slaves=$(awk -F: '/^connected_slaves:/{print $2}' <<< "$info")
+    if [ "${slaves:-0}" -lt $((expected - 1)) ]; then
+      echo "VALKEY REPLICATION CRITICAL: primary with ${slaves:-0}/$((expected - 1)) replicas connected"
+      exit 2
+    fi
+    echo "VALKEY REPLICATION OK: primary, ${slaves}/$((expected - 1)) replicas connected"
+    ;;
+  slave)
+    link=$(awk -F: '/^master_link_status:/{print $2}' <<< "$info")
+    if [ "$link" != "up" ]; then
+      echo "VALKEY REPLICATION CRITICAL: replica link ${link:-unknown}"
+      exit 2
+    fi
+    echo 'VALKEY REPLICATION OK: replica, link up'
+    ;;
+  *)
+    echo 'VALKEY REPLICATION UNKNOWN: unable to read replication info'
+    exit 3
+    ;;
+esac
+exit 0

--- a/files/default/check_valkey_sentinel
+++ b/files/default/check_valkey_sentinel
@@ -1,0 +1,26 @@
+#!/bin/bash
+# NRPE check: sentinel reaches quorum + failover authorization for the
+# lock service and has discovered every other member's sentinel. No
+# auth: sentinel takes none (tooz yoga clients cannot send it), access
+# is limited by the OSL-only firewall.
+name="${1:?usage: check_valkey_sentinel <service_name> <cluster_size>}"
+expected="${2:?usage: check_valkey_sentinel <service_name> <cluster_size>}"
+
+ck=$(/usr/bin/valkey-cli -p 26379 sentinel ckquorum "$name" 2>&1)
+case "$ck" in
+  OK*) ;;
+  *)
+    echo "VALKEY SENTINEL CRITICAL: ${ck:-no reply}"
+    exit 2
+    ;;
+esac
+
+others=$(/usr/bin/valkey-cli -p 26379 sentinel master "$name" 2>/dev/null |
+  tr -d '\r' | awk '/^num-other-sentinels$/{getline; print}')
+if [ -z "$others" ] || [ "$others" -lt $((expected - 1)) ]; then
+  echo "VALKEY SENTINEL CRITICAL: ${others:-0}/$((expected - 1)) other sentinels known"
+  exit 2
+fi
+
+echo "VALKEY SENTINEL OK: ${ck}"
+exit 0

--- a/kitchen.multi-node.yml
+++ b/kitchen.multi-node.yml
@@ -60,6 +60,7 @@ verifier:
       hosts_output: mq1
       user: almalinux
       profile_locations:
+        - test/integration/coordination_tier
         - test/integration/messaging_tier
       attrs:
         - test/integration/multi-node/mq.yml
@@ -69,6 +70,7 @@ verifier:
       hosts_output: mq2
       user: almalinux
       profile_locations:
+        - test/integration/coordination_tier
         - test/integration/messaging_tier
       attrs:
         - test/integration/multi-node/mq.yml
@@ -78,6 +80,7 @@ verifier:
       hosts_output: mq3
       user: almalinux
       profile_locations:
+        - test/integration/coordination_tier
         - test/integration/messaging_tier
       attrs:
         - test/integration/multi-node/mq.yml

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -47,6 +47,10 @@ suites:
       - role[openstack_tk]
       - recipe[osl-openstack::ops_messaging]
   - name: messaging_tier
+    # The tier runs on EL10 only (RabbitMQ 4.2 + valkey from AppStream).
+    excludes:
+      - almalinux-8
+      - almalinux-9
     driver_config:
       server_name: "messaging-tier-<%= ENV['USER'] %>"
     attributes:
@@ -56,9 +60,11 @@ suites:
     run_list:
       - role[openstack_tk]
       - recipe[osl-openstack::ops_messaging]
+      - recipe[osl-openstack::ops_coordination]
       - recipe[osl-openstack::mon]
     verifier:
       inspec_tests:
+        - test/integration/coordination_tier
         - test/integration/messaging_tier
       inputs:
         nrpe_checks: true

--- a/main.tf
+++ b/main.tf
@@ -585,7 +585,7 @@ resource "null_resource" "mq1" {
             knife bootstrap -c test/chef-config/knife.rb \
                 ${var.ssh_user_name}@${openstack_compute_instance_v2.mq1.network.0.fixed_ip_v4} \
                 --bootstrap-version ${var.chef_version} -y -N mq1 --sudo \
-                -r 'role[openstack_tf],recipe[osl-selinux],recipe[openstack_test::hosts_tf],recipe[osl-openstack::ops_messaging]'
+                -r 'role[openstack_tf],recipe[osl-selinux],recipe[openstack_test::hosts_tf],recipe[osl-openstack::ops_messaging],recipe[osl-openstack::ops_coordination]'
             EOF
         environment = {
             CHEF_SERVER = "${openstack_compute_instance_v2.chef_zero.network.0.fixed_ip_v4}"
@@ -619,7 +619,7 @@ resource "null_resource" "mq2" {
             knife bootstrap -c test/chef-config/knife.rb \
                 ${var.ssh_user_name}@${openstack_compute_instance_v2.mq2.network.0.fixed_ip_v4} \
                 --bootstrap-version ${var.chef_version} -y -N mq2 --sudo \
-                -r 'role[openstack_tf],recipe[osl-selinux],recipe[openstack_test::hosts_tf],recipe[osl-openstack::ops_messaging]'
+                -r 'role[openstack_tf],recipe[osl-selinux],recipe[openstack_test::hosts_tf],recipe[osl-openstack::ops_messaging],recipe[osl-openstack::ops_coordination]'
             EOF
         environment = {
             CHEF_SERVER = "${openstack_compute_instance_v2.chef_zero.network.0.fixed_ip_v4}"
@@ -653,7 +653,7 @@ resource "null_resource" "mq3" {
             knife bootstrap -c test/chef-config/knife.rb \
                 ${var.ssh_user_name}@${openstack_compute_instance_v2.mq3.network.0.fixed_ip_v4} \
                 --bootstrap-version ${var.chef_version} -y -N mq3 --sudo \
-                -r 'role[openstack_tf],recipe[osl-selinux],recipe[openstack_test::hosts_tf],recipe[osl-openstack::ops_messaging]'
+                -r 'role[openstack_tf],recipe[osl-selinux],recipe[openstack_test::hosts_tf],recipe[osl-openstack::ops_messaging],recipe[osl-openstack::ops_coordination]'
             EOF
         environment = {
             CHEF_SERVER = "${openstack_compute_instance_v2.chef_zero.network.0.fixed_ip_v4}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -24,6 +24,7 @@ depends 'osl-nrpe'
 depends 'osl-prometheus'
 depends 'osl-repos'
 depends 'osl-resources'
+depends 'osl-valkey'
 depends 'yum-kernel-osuosl'
 depends 'yum-osuosl'
 

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -154,4 +154,46 @@ if node['osl-openstack']['node_type'] == 'messaging'
     command 'sudo /usr/sbin/rabbitmq-diagnostics'
     parameters "-q check_port_listener #{listen_port}"
   end
+
+  # Valkey coordination (tooz lock) service on the same tier nodes.
+  if s['coordination']
+    c = s['coordination']
+    cluster_size = c['endpoint'] ? Array(c['endpoint']).count : 1
+
+    %w(check_valkey check_valkey_replication check_valkey_sentinel).each do |chk|
+      cookbook_file "#{node['nrpe']['plugin_dir']}/#{chk}" do
+        mode '755'
+      end
+    end
+
+    # check_valkey and check_valkey_replication read requirepass out of
+    # /etc/valkey/valkey.conf (root-only), so they run through the same
+    # sudo grant pattern as the rabbitmq checks; the sentinel check
+    # needs no auth at all.
+    %w(nagios nrpe).each do |u|
+      sudo "check_valkey-#{u}" do
+        user u
+        runas 'root'
+        nopasswd true
+        commands [
+          "#{node['nrpe']['plugin_dir']}/check_valkey",
+          "#{node['nrpe']['plugin_dir']}/check_valkey_replication",
+        ]
+      end
+    end
+
+    nrpe_check 'check_valkey' do
+      command "sudo #{node['nrpe']['plugin_dir']}/check_valkey"
+    end
+
+    nrpe_check 'check_valkey_replication' do
+      command "sudo #{node['nrpe']['plugin_dir']}/check_valkey_replication"
+      parameters cluster_size.to_s
+    end
+
+    nrpe_check 'check_valkey_sentinel' do
+      command "#{node['nrpe']['plugin_dir']}/check_valkey_sentinel"
+      parameters "#{c['service_name'] || 'oslocks'} #{cluster_size}"
+    end
+  end
 end

--- a/recipes/ops_coordination.rb
+++ b/recipes/ops_coordination.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook:: osl-openstack
+# Recipe:: ops_coordination
+#
+# Copyright:: 2026, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+s = os_secrets['coordination']
+
+osl_openstack_coordination 'default' do
+  pass s['pass']
+  nodes s['endpoint'] if s['endpoint']
+  primary s['primary'] if s['primary']
+  service_name s['service_name'] if s['service_name']
+  down_after_ms s['down_after_ms'] if s['down_after_ms']
+  failover_timeout_ms s['failover_timeout_ms'] if s['failover_timeout_ms']
+  config_version s['config_version'] if s['config_version']
+end

--- a/resources/coordination.rb
+++ b/resources/coordination.rb
@@ -1,0 +1,66 @@
+resource_name :osl_openstack_coordination
+provides :osl_openstack_coordination
+default_action :create
+unified_mode true
+
+# Shared valkey + sentinel service on the mq tier, providing tooz
+# distributed locks ([coordination] backend_url) for the clouds via the
+# redis:// driver. One valkey per tier node (one primary, the rest
+# replicas), sentinel on every node handling primary failover. The
+# valkey/sentinel mechanics live in the osl-valkey cookbook; this
+# resource only maps the tier topology (data bag driven) onto it.
+
+property :pass, String, sensitive: true, required: true
+
+# All tier node FQDNs; sizes the sentinel quorum ((N/2)+1). Empty =
+# standalone single node (the kitchen suite).
+property :nodes, Array, default: []
+
+# FQDN of the initial primary; absent = this node is a standalone
+# primary. Replicas are any node whose short hostname doesn't match.
+property :primary, String
+
+# Sentinel master name; clouds reference it in their backend_url.
+property :service_name, String, default: 'oslocks'
+
+property :down_after_ms, Integer, default: 5000
+property :failover_timeout_ms, Integer, default: 60000
+
+# Passed through to the seed-once configs in osl-valkey; bump to force
+# a re-seed + restart (also resets failover state to the seeded
+# topology, so treat as a maintenance action).
+property :config_version, Integer, default: 1
+
+action :create do
+  # Short-hostname compare, exact match (mq1 vs mq10), mirroring the
+  # rabbitmq primary detection.
+  primary_node = new_resource.primary
+  replica = primary_node && primary_node.split('.', 2).first != node['hostname']
+  clustered = new_resource.nodes.count > 1
+  quorum = clustered ? (new_resource.nodes.count / 2) + 1 : 1
+
+  # 6379/26379 are opened OSL-only by the osl-valkey resources. tooz
+  # 2.10.1 (yoga) has no sentinel auth support, so the firewall is the
+  # only guard on sentinel; valkey itself requires the password.
+  osl_valkey 'coordination' do
+    pass new_resource.pass
+    replicaof primary_node if replica
+    # An evicted key is a silently released lock; held locks must
+    # survive a restart.
+    maxmemory_policy 'noeviction'
+    appendonly true
+    # On the tier, a primary that loses both replicas goes read-only
+    # rather than granting locks the rest of the cluster cannot see.
+    min_replicas_to_write 1 if clustered
+    config_version new_resource.config_version
+  end
+
+  osl_valkey_sentinel new_resource.service_name do
+    monitor_host primary_node || '127.0.0.1'
+    quorum quorum
+    pass new_resource.pass
+    down_after_ms new_resource.down_after_ms
+    failover_timeout_ms new_resource.failover_timeout_ms
+    config_version new_resource.config_version
+  end
+end

--- a/spec/unit/recipes/mon_spec.rb
+++ b/spec/unit/recipes/mon_spec.rb
@@ -183,6 +183,69 @@ describe 'osl-openstack::mon' do
           )
         end
 
+        # No coordination block in the bag: no valkey checks.
+        it { is_expected.to_not add_nrpe_check 'check_valkey' }
+
+        context 'coordination tier' do
+          cached(:chef_run) do
+            ChefSpec::SoloRunner.new(pltfrm) do |node|
+              node.normal['osl-openstack']['node_type'] = 'messaging'
+            end.converge(described_recipe)
+          end
+
+          before do
+            stub_data_bag_item('openstack', 'x86').and_return(
+              openstack_secrets_stub.merge(
+                'coordination' => {
+                  'endpoint' => %w(
+                    mq1.testing.osuosl.org
+                    mq2.testing.osuosl.org
+                    mq3.testing.osuosl.org
+                  ),
+                  'primary' => 'mq1.testing.osuosl.org',
+                  'pass' => 'oslocks',
+                }
+              )
+            )
+          end
+
+          %w(check_valkey check_valkey_replication check_valkey_sentinel).each do |chk|
+            it { is_expected.to create_cookbook_file("/usr/lib64/nagios/plugins/#{chk}").with(mode: '755') }
+          end
+
+          %w(nagios nrpe).each do |u|
+            it do
+              is_expected.to create_sudo("check_valkey-#{u}").with(
+                user: [u],
+                runas: 'root',
+                nopasswd: true,
+                commands: %w(
+                  /usr/lib64/nagios/plugins/check_valkey
+                  /usr/lib64/nagios/plugins/check_valkey_replication
+                )
+              )
+            end
+          end
+
+          it do
+            is_expected.to add_nrpe_check('check_valkey').with(
+              command: 'sudo /usr/lib64/nagios/plugins/check_valkey'
+            )
+          end
+          it do
+            is_expected.to add_nrpe_check('check_valkey_replication').with(
+              command: 'sudo /usr/lib64/nagios/plugins/check_valkey_replication',
+              parameters: '3'
+            )
+          end
+          it do
+            is_expected.to add_nrpe_check('check_valkey_sentinel').with(
+              command: '/usr/lib64/nagios/plugins/check_valkey_sentinel',
+              parameters: 'oslocks 3'
+            )
+          end
+        end
+
         context 'TLS tier' do
           cached(:chef_run) do
             ChefSpec::SoloRunner.new(pltfrm) do |node|

--- a/spec/unit/recipes/ops_coordination_spec.rb
+++ b/spec/unit/recipes/ops_coordination_spec.rb
@@ -1,0 +1,151 @@
+require_relative '../../spec_helper'
+
+describe 'osl-openstack::ops_coordination' do
+  # The coordination tier runs on the EL10 mq nodes only, so other
+  # platforms are deliberately not tested. The valkey/sentinel
+  # mechanics (configs, services, firewall) are covered by the
+  # osl-valkey cookbook's own specs; here we assert the data bag to
+  # resource mapping.
+  [ALMA_10].each do |pltfrm|
+    context "#{pltfrm[:platform]} #{pltfrm[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(pltfrm.dup.merge(
+          step_into: %w(osl_openstack_coordination)
+        )).converge(described_recipe)
+      end
+
+      include_context 'common_stubs'
+
+      # Single standalone node, like the messaging_tier kitchen suite.
+      before do
+        stub_data_bag_item('openstack', 'x86').and_return(
+          openstack_secrets_stub.merge('coordination' => { 'pass' => 'oslocks' })
+        )
+      end
+
+      it { is_expected.to create_osl_openstack_coordination('default').with(pass: 'oslocks') }
+      it do
+        is_expected.to create_osl_valkey('coordination').with(
+          pass: 'oslocks',
+          replicaof: nil,
+          appendonly: true,
+          maxmemory_policy: 'noeviction',
+          min_replicas_to_write: nil,
+          config_version: 1
+        )
+      end
+      it do
+        is_expected.to create_osl_valkey_sentinel('oslocks').with(
+          monitor_host: '127.0.0.1',
+          quorum: 1,
+          pass: 'oslocks',
+          down_after_ms: 5000,
+          failover_timeout_ms: 60_000
+        )
+      end
+
+      context 'tier primary' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm.dup.merge(
+            step_into: %w(osl_openstack_coordination)
+          )) { |node| node.automatic['hostname'] = 'mq1' }.converge(described_recipe)
+        end
+
+        before do
+          stub_data_bag_item('openstack', 'x86').and_return(
+            openstack_secrets_stub.merge(
+              'coordination' => {
+                'endpoint' => %w(
+                  mq1.testing.osuosl.org
+                  mq2.testing.osuosl.org
+                  mq3.testing.osuosl.org
+                ),
+                'primary' => 'mq1.testing.osuosl.org',
+                'pass' => 'oslocks',
+              }
+            )
+          )
+        end
+
+        it do
+          is_expected.to create_osl_valkey('coordination').with(
+            replicaof: nil,
+            min_replicas_to_write: 1
+          )
+        end
+        it do
+          is_expected.to create_osl_valkey_sentinel('oslocks').with(
+            monitor_host: 'mq1.testing.osuosl.org',
+            quorum: 2
+          )
+        end
+      end
+
+      context 'tier replica' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm.dup.merge(
+            step_into: %w(osl_openstack_coordination)
+          )) { |node| node.automatic['hostname'] = 'mq2' }.converge(described_recipe)
+        end
+
+        before do
+          stub_data_bag_item('openstack', 'x86').and_return(
+            openstack_secrets_stub.merge(
+              'coordination' => {
+                'endpoint' => %w(
+                  mq1.testing.osuosl.org
+                  mq2.testing.osuosl.org
+                  mq3.testing.osuosl.org
+                ),
+                'primary' => 'mq1.testing.osuosl.org',
+                'pass' => 'oslocks',
+              }
+            )
+          )
+        end
+
+        it do
+          is_expected.to create_osl_valkey('coordination').with(
+            replicaof: 'mq1.testing.osuosl.org',
+            min_replicas_to_write: 1
+          )
+        end
+        it do
+          is_expected.to create_osl_valkey_sentinel('oslocks').with(
+            monitor_host: 'mq1.testing.osuosl.org',
+            quorum: 2
+          )
+        end
+      end
+
+      context 'custom tuning' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm.dup.merge(
+            step_into: %w(osl_openstack_coordination)
+          )).converge(described_recipe)
+        end
+
+        before do
+          stub_data_bag_item('openstack', 'x86').and_return(
+            openstack_secrets_stub.merge(
+              'coordination' => {
+                'pass' => 'oslocks',
+                'service_name' => 'oslocks2',
+                'down_after_ms' => 10_000,
+                'config_version' => 3,
+              }
+            )
+          )
+        end
+
+        it { is_expected.to create_osl_valkey('coordination').with(config_version: 3) }
+        it do
+          is_expected.to create_osl_valkey_sentinel('oslocks2').with(
+            down_after_ms: 10_000,
+            config_version: 3
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/integration/coordination_tier/controls/coordination_tier.rb
+++ b/test/integration/coordination_tier/controls/coordination_tier.rb
@@ -1,0 +1,95 @@
+# Valkey + sentinel coverage for the shared coordination (tooz lock)
+# tier. Defaults cover the single-node kitchen suite; the multi-node env
+# passes cluster_size 3 via mq.yml to also assert replication and
+# sentinel quorum.
+cluster_size = input('cluster_size', value: 1)
+service_name = input('coordination_service_name', value: 'oslocks')
+valkey_pass = input('valkey_pass', value: 'oslocks')
+# Set only by the single-node suite (the multi-node mq systems don't
+# run osl-openstack::mon).
+nrpe_checks = input('nrpe_checks', value: false)
+
+control 'coordination_tier' do
+  %w(valkey valkey-sentinel).each do |svc|
+    describe service(svc) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+  end
+
+  describe port(6379) do
+    it { should be_listening }
+    its('protocols') { should include 'tcp' }
+  end
+  describe port(26379) do
+    it { should be_listening }
+    its('protocols') { should include 'tcp' }
+  end
+
+  # Chef-seeded config: no eviction (an evicted key is a silently
+  # released lock) and AOF persistence (held locks survive a restart).
+  describe file('/etc/valkey/valkey.conf') do
+    its('content') { should match(/^maxmemory-policy noeviction$/) }
+    its('content') { should match(/^appendonly yes$/) }
+  end
+
+  # Unauthenticated access must be refused, the configured password
+  # accepted.
+  describe command('valkey-cli ping') do
+    its('stdout') { should match(/NOAUTH/) }
+  end
+  describe command("valkey-cli -a '#{valkey_pass}' --no-auth-warning ping") do
+    its('stdout') { should match(/^PONG$/) }
+  end
+
+  # Sentinel monitors the service and can reach quorum + failover
+  # authorization with the sentinels it sees.
+  describe command("valkey-cli -p 26379 sentinel ckquorum #{service_name}") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/OK #{cluster_size} usable Sentinels/) }
+  end
+
+  # Operator tooling from osl-valkey sees a healthy service end to end.
+  describe command('/usr/local/bin/valkey-status') do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/ckquorum: OK/) }
+  end
+
+  if cluster_size > 1
+    # Every member is the primary or a replica of it.
+    describe command("valkey-cli -a '#{valkey_pass}' --no-auth-warning info replication") do
+      its('stdout') { should match(/^role:(master|slave)/) }
+    end
+    # Any sentinel reports the full replica set.
+    describe command("valkey-cli -p 26379 sentinel master #{service_name}") do
+      its('stdout') { should match(/num-slaves\s+#{cluster_size - 1}\s/) }
+    end
+  end
+
+  # NRPE checks from osl-openstack::mon, run exactly as NRPE would (as
+  # the nrpe user, through its sudo grant where the check needs one).
+  if nrpe_checks
+    %w(
+      check_valkey
+      check_valkey_replication
+      check_valkey_sentinel
+    ).each do |chk|
+      describe file("/etc/nagios/nrpe.d/#{chk}.cfg") do
+        it { should exist }
+      end
+    end
+
+    describe command('sudo -u nrpe sudo /usr/lib64/nagios/plugins/check_valkey') do
+      its('exit_status') { should eq 0 }
+      its('stdout') { should match(/^VALKEY OK/) }
+    end
+    describe command("sudo -u nrpe sudo /usr/lib64/nagios/plugins/check_valkey_replication #{cluster_size}") do
+      its('exit_status') { should eq 0 }
+      its('stdout') { should match(/^VALKEY REPLICATION OK/) }
+    end
+    describe command("sudo -u nrpe /usr/lib64/nagios/plugins/check_valkey_sentinel #{service_name} #{cluster_size}") do
+      its('exit_status') { should eq 0 }
+      its('stdout') { should match(/^VALKEY SENTINEL OK/) }
+    end
+  end
+end

--- a/test/integration/coordination_tier/inspec.yml
+++ b/test/integration/coordination_tier/inspec.yml
@@ -1,0 +1,2 @@
+---
+name: coordination_tier

--- a/test/integration/data_bags/openstack/messaging_tier.json
+++ b/test/integration/data_bags/openstack/messaging_tier.json
@@ -1,5 +1,8 @@
 {
   "id": "messaging_tier",
+  "coordination": {
+    "pass": "oslocks"
+  },
   "messaging": {
     "user": "openstack",
     "pass": "openstack",

--- a/test/integration/data_bags/openstack/multinode.json
+++ b/test/integration/data_bags/openstack/multinode.json
@@ -75,6 +75,15 @@
       "pass": "nova"
     }
   },
+  "coordination": {
+    "endpoint": [
+      "mq1.testing.osuosl.org",
+      "mq2.testing.osuosl.org",
+      "mq3.testing.osuosl.org"
+    ],
+    "primary": "mq1.testing.osuosl.org",
+    "pass": "oslocks"
+  },
   "dashboard": {
     "aliases":[
       "controller1.testing.osuosl.org"


### PR DESCRIPTION
Shared distributed-lock service for tooz (`[coordination] backend_url`),
replacing the broken mysql backend (dropped in the follow-up cinder change):
one valkey per mq node (mq1 primary, mq2/mq3 replicas), sentinel on all three
monitoring `oslocks` with quorum (N/2)+1. One instance serves all three
clouds, separated by redis db index.

- The valkey/sentinel mechanics (package, seed-once configs, services,
  OSL-only firewall, `valkey-status`/`valkey-failover` operator tools) live in
  the new [osl-valkey](https://github.com/osuosl-cookbooks/osl-valkey)
  cookbook (released as 1.0.0); `osl_openstack_coordination` maps the tier
  topology onto its `osl_valkey` + `osl_valkey_sentinel` resources, driven by
  a new `coordination` data bag block (endpoint/primary/pass plus optional
  tuning keys)
- Lock-service settings: required auth, noeviction (an evicted key is a
  released lock), AOF so held locks survive restarts, and
  `min-replicas-to-write 1` when clustered so an isolated ex-primary goes
  read-only instead of granting locks the promoted side never sees; sentinel
  takes no client auth because tooz 2.10.1 (yoga) cannot send it, so
  6379/26379 are OSL-only
- Configs are seeded once (valkey and sentinel rewrite them at runtime); bump
  `coordination.config_version` to force a re-seed
- NRPE checks on the tier via mon: authenticated PING, replication health
  (role-aware, survives failovers), sentinel quorum/membership; auth-reading
  checks go through the rabbitmq-style sudo grants
- Tests: ChefSpec asserting the data bag to resource mapping, a
  `coordination_tier` inspec profile on the `messaging_tier` kitchen suite
  (now EL10-only), and the multi-node env runs the recipe on mq1-3 asserting
  replication and sentinel quorum
- `docs/COORDINATION_TIER.md` covers the design, seed-once risks, production
  deployment, failover validation and follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)