### PR TITLE
Point cinder tooz coordination at the valkey tier

### DIFF
--- a/docs/COORDINATION_TIER.md
+++ b/docs/COORDINATION_TIER.md
@@ -1,8 +1,9 @@
 # Design: shared valkey coordination (tooz lock) tier
 
-Status: tier implemented in the cookbook (`ops_coordination` on the mq
-nodes); the client side (cinder pointing tooz at it) lands as a
-follow-up change. Runs on the same three mq nodes as the
+Status: implemented in the cookbook, tier (`ops_coordination` on the
+mq nodes) and client side (cinder renders the redis:// backend_url
+when the cloud's bag item has a `coordination` block). Runs on the
+same three mq nodes as the
 [shared RabbitMQ messaging tier](SHARED_MESSAGING_TIER.md).
 
 ## Motivation
@@ -16,9 +17,13 @@ On top of that, `GET_LOCK` locks are local to the server a session is
 connected to and are not Galera-replicated, so the mysql driver never
 provided real cross-node exclusion behind the HA frontend.
 
-The follow-up cinder change drops the mysql `backend_url` and points
-tooz at this tier via the `redis://` driver (valkey is
-protocol-compatible with redis), restoring working distributed locks.
+The cinder change drops the mysql `backend_url` entirely and renders
+the tooz `redis://` form against this tier (valkey is
+protocol-compatible with redis) once a cloud's bag item carries a
+`coordination` block. A cloud without the block renders no
+`[coordination]` section at all, so cinder falls back to node-local
+oslo file locks; that restores attach on its own and makes the
+per-cloud cutover a data bag edit, not a code deploy.
 
 Rejected alternatives: etcd (fine, but valkey is preferred for reuse
 potential and operator familiarity); patching the tooz mysql driver to
@@ -201,25 +206,38 @@ services) is chef-managed.
    owns the topology after the seed. A converge during or after a
    failover is a no-op on the configs.
 
-## Client side (follow-up change)
+## Client side (per-cloud cutover)
 
-Each cloud's `cinder.conf` gets, via its data bag item's
-`coordination` block:
+Adding the `coordination` block (with the cloud's `db` index) to a
+cloud's bag item makes `openstack_coordination_url` render in that
+cloud's `cinder.conf`:
 
 ```ini
 [coordination]
 backend_url = redis://:<pass>@mq1:26379?sentinel=oslocks&sentinel_fallback=mq2:26379&sentinel_fallback=mq3:26379&db=<N>
 ```
 
-Controllers need `python3-redis` (in the yoga RDO repos, noarch, all
-arches). Rollout x86 first (it has the known-broken attach to verify
-against), then arm, then ppc. Verification per cloud: attach/detach
-smoke test on a scratch VM, stuck `reserved` attachments cleaned up,
-and lock keys visible during an attach:
+The converge installs `python3-redis` (yoga RDO repos, noarch, all
+arches) and restarts cinder-scheduler and cinder-volume plus reloads
+httpd (cinder-api runs under mod_wsgi; its log is
+/var/log/httpd/cinder-api) via the existing cinder.conf subscriptions.
+cinder-backup is not chef-managed; restart it by hand where it runs.
+
+Rollout x86 first (it has the known-broken attach to verify against),
+then arm, then ppc. Verification per cloud:
+
+- attach/detach smoke test on a scratch VM
+- stuck `reserved` attachments cleaned up
+  (`openstack volume attachment list`)
+- lock keys visible during an attach:
 
 ```bash
 valkey-cli -a "$PASS" --no-auth-warning -n <db> --scan --pattern '_tooz*'
 ```
+
+cinder is the only tooz consumer in this cookbook (no other rendered
+config sets a `backend_url`); designate/octavia/gnocchi are not
+deployed here.
 
 ## Monitoring
 

--- a/docs/HA_MIGRATION.md
+++ b/docs/HA_MIGRATION.md
@@ -704,9 +704,20 @@ SNAT outbound from instances must keep the same address.
 
 `block-storage.cluster` was added in the A2 data-bag MR, so by this
 point `cinder.conf` on both controllers renders the `cluster =
-<name>` and `[coordination] backend_url = mysql://...` blocks. After
-both `cinder-volume` services have restarted (which C2 / C3 take care
-of), verify:
+<name>` block. After both `cinder-volume` services have restarted
+(which C2 / C3 take care of), verify:
+
+> **Note:** the original migration also rendered `[coordination]
+> backend_url = mysql://...` here. That was removed: the tooz mysql
+> driver passes lock names to `GET_LOCK()` raw, and cinder's
+> `cinder-attachment_update-<uuid>-<host>` names exceed MySQL 8.0's
+> 64-char limit, failing every attachment update with HTTP 500 (and
+> `GET_LOCK` locks are per-server, not Galera-replicated, so the
+> driver never provided cross-node exclusion anyway). The section now
+> renders only when the cloud's bag item has a `coordination` block
+> pointing at the shared valkey tier (see
+> [COORDINATION_TIER.md](COORDINATION_TIER.md)); without one, cinder
+> falls back to local oslo file locks.
 
 ```bash
 cinder-manage cluster list

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -220,6 +220,22 @@ module OSLOpenstack
         openstack_memcached_endpoints.join(',')
       end
 
+      # tooz backend_url for the shared valkey coordination tier, in the
+      # redis:// sentinel form with the per-cloud db index. nil when the
+      # cloud has no coordination block (no [coordination] section
+      # renders). tooz 2.10.1 (yoga) accepts sentinel/sentinel_fallback/
+      # db as query args and only the userinfo password, so the sentinels
+      # themselves are unauthenticated; see docs/COORDINATION_TIER.md.
+      def openstack_coordination_url
+        c = safe_dig(os_secrets, 'coordination')
+        return unless c
+        first, *fallbacks = Array(c['endpoint']).sort
+        args = ["sentinel=#{c['service_name'] || 'oslocks'}"]
+        args += fallbacks.map { |host| "sentinel_fallback=#{host}:26379" }
+        args << "db=#{c['db'] || 0}"
+        "redis://:#{c['pass']}@#{first}:26379?#{args.join('&')}"
+      end
+
       # Per-host listen address for Apache/WSGI vhosts so that HAProxy can
       # bind to the VIP on the same port. Returns '*' when the cloud is not
       # configured for HA (back-compat with single-controller deployments).

--- a/recipes/block_storage_common.rb
+++ b/recipes/block_storage_common.rb
@@ -25,6 +25,9 @@ include_recipe 'osl-ceph'
 
 package 'openstack-cinder'
 
+# redis client for the tooz redis:// coordination driver.
+package 'python3-redis'
+
 db_connection = openstack_database_connection('block-storage')
 
 template '/etc/cinder/cinder.conf' do
@@ -40,7 +43,7 @@ template '/etc/cinder/cinder.conf' do
     block_ssd_rbd_pool: b['ceph']['block_ssd_rbd_pool'],
     cluster: b['cluster'],
     compute_pass: s['compute']['service']['pass'],
-    coordination_url: db_connection.sub('mysql+pymysql', 'mysql'),
+    coordination_url: openstack_coordination_url,
     database_connection: db_connection,
     image_api_servers: openstack_image_api_servers,
     memcached_endpoint: openstack_memcached_servers,

--- a/spec/unit/recipes/block_storage_controller_spec.rb
+++ b/spec/unit/recipes/block_storage_controller_spec.rb
@@ -51,6 +51,7 @@ describe 'osl-openstack::block_storage_controller' do
       end
       it { is_expected.to include_recipe 'osl-openstack::block_storage_common' }
       it { is_expected.to install_package 'openstack-cinder' }
+      it { is_expected.to install_package 'python3-redis' }
       it do
         is_expected.to create_template('/etc/cinder/cinder.conf').with(
           owner: 'root',
@@ -65,7 +66,7 @@ describe 'osl-openstack::block_storage_controller' do
             block_ssd_rbd_pool: 'volumes_ssd',
             cluster: nil,
             compute_pass: 'nova',
-            coordination_url: 'mysql://cinder_x86:cinder@localhost:3306/cinder_x86',
+            coordination_url: nil,
             database_connection: 'mysql+pymysql://cinder_x86:cinder@localhost:3306/cinder_x86',
             image_api_servers: 'http://controller.testing.osuosl.org:9292',
             memcached_endpoint: 'controller.testing.osuosl.org:11211',
@@ -110,6 +111,40 @@ describe 'osl-openstack::block_storage_controller' do
       it do
         expect(chef_run.service('openstack-cinder-scheduler')).to \
           subscribe_to('template[/etc/cinder/cinder.conf]').on(:restart)
+      end
+      it { is_expected.to_not render_file('/etc/cinder/cinder.conf').with_content(/^\[coordination\]$/) }
+
+      context 'valkey coordination' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm).converge(described_recipe)
+        end
+
+        before do
+          stub_data_bag_item('openstack', 'x86').and_return(
+            openstack_secrets_stub.merge(
+              'coordination' => {
+                'endpoint' => %w(
+                  mq1.testing.osuosl.org
+                  mq2.testing.osuosl.org
+                  mq3.testing.osuosl.org
+                ),
+                'primary' => 'mq1.testing.osuosl.org',
+                'pass' => 'oslocks',
+                'db' => 1,
+              }
+            )
+          )
+        end
+
+        it do
+          is_expected.to render_file('/etc/cinder/cinder.conf').with_content(
+            'backend_url = redis://:oslocks@mq1.testing.osuosl.org:26379' \
+            '?sentinel=oslocks' \
+            '&sentinel_fallback=mq2.testing.osuosl.org:26379' \
+            '&sentinel_fallback=mq3.testing.osuosl.org:26379' \
+            '&db=1'
+          )
+        end
       end
     end
   end

--- a/templates/cinder.conf.erb
+++ b/templates/cinder.conf.erb
@@ -22,12 +22,11 @@ state_path = /var/lib/cinder
 transport_url = <%= @transport_url %>
 volume_clear_size = 256
 
-<% if @cluster -%>
+<% if @coordination_url -%>
 [coordination]
 backend_url = <%= @coordination_url %>
 
 <% end -%>
-
 [cache]
 memcache_servers = <%= @memcached_endpoint %>
 enabled = true

--- a/test/integration/block_storage_controller/controls/block_storage_controller_spec.rb
+++ b/test/integration/block_storage_controller/controls/block_storage_controller_spec.rb
@@ -2,6 +2,9 @@ db_endpoint = input('db_endpoint')
 # memcached_host = the memcached backend (controller1 on multi-node);
 # this profile has no transport_url check.
 memcached_host = input('memcached_host', value: 'controller.testing.osuosl.org')
+# tooz backend_url; set by the multi-node env (valkey on the mq tier),
+# empty on the single-node suites (no coordination block in the bag).
+coordination_url = input('coordination_url', value: '')
 
 control 'block-storage-controller' do
   describe package 'openstack-cinder' do
@@ -65,6 +68,12 @@ control 'block-storage-controller' do
     its('nova.auth_url') { should cmp 'https://controller.testing.osuosl.org:5000/v3' }
     its('nova.password') { should cmp 'nova' }
     its('oslo_messaging_notifications.driver') { should cmp 'messagingv2' }
+  end
+
+  unless coordination_url.empty?
+    describe ini('/etc/cinder/cinder.conf') do
+      its('coordination.backend_url') { should cmp coordination_url }
+    end
   end
 
   openstack = 'bash -c "source /root/openrc && /usr/bin/openstack'

--- a/test/integration/data_bags/openstack/multinode.json
+++ b/test/integration/data_bags/openstack/multinode.json
@@ -82,7 +82,8 @@
       "mq3.testing.osuosl.org"
     ],
     "primary": "mq1.testing.osuosl.org",
-    "pass": "oslocks"
+    "pass": "oslocks",
+    "db": 0
   },
   "dashboard": {
     "aliases":[

--- a/test/integration/multi-node/controller1.yml
+++ b/test/integration/multi-node/controller1.yml
@@ -16,3 +16,5 @@ skip_ssl_baseline: true
 # Tells the dashboard / compute_controller controls to skip
 # localhost:443-HTTPS probes and the local novnc cert assertions.
 haproxy_tls: true
+# cinder tooz locks via valkey/sentinel on the mq tier.
+coordination_url: redis://:oslocks@mq1.testing.osuosl.org:26379?sentinel=oslocks&sentinel_fallback=mq2.testing.osuosl.org:26379&sentinel_fallback=mq3.testing.osuosl.org:26379&db=0

--- a/test/integration/multi-node/controller2.yml
+++ b/test/integration/multi-node/controller2.yml
@@ -15,3 +15,5 @@ haproxy_tls: true
 # recipes - those run only on the primary controller. Skip the
 # corresponding InSpec checks so this controller doesn't fail them.
 primary_controller: false
+# cinder tooz locks via valkey/sentinel on the mq tier.
+coordination_url: redis://:oslocks@mq1.testing.osuosl.org:26379?sentinel=oslocks&sentinel_fallback=mq2.testing.osuosl.org:26379&sentinel_fallback=mq3.testing.osuosl.org:26379&db=0


### PR DESCRIPTION
Follow-up to #272: replaces the broken mysql tooz backend with the valkey/
sentinel tier in one step. The mysql driver failed every attachment_update
with HTTP 500 - cinder's `cinder-attachment_update-<uuid>-<host>` lock names
always exceed 64 chars and the driver passes them raw into `GET_LOCK()`,
which MySQL/Percona 8.0 hard-rejects (error 4163); `GET_LOCK` locks are also
per-server and never Galera-replicated, so the backend provided no
cross-node exclusion anyway.

- New `openstack_coordination_url` helper renders `[coordination]
  backend_url` whenever the cloud's data bag item has a `coordination`
  block: `redis://` against sentinel on the mq tier, `sentinel_fallback` for
  the other two nodes, per-cloud db index (x86 0, arm 1, ppc 2). Verified
  against tooz 2.10.1 (yoga, all clusters): `sentinel`/`sentinel_fallback`/
  `db` are accepted query args and the password rides in the URL userinfo
- A cloud without a coordination block renders no `[coordination]` section
  at all, so merging this alone already stops the broken mysql locks (cinder
  falls back to node-local oslo file locks); each cloud then cuts over to
  the tier with just a data bag edit (`endpoint`, `pass`, distinct `db`)
- Install `python3-redis` (tooz redis driver dep) in
  `block_storage_common`; noarch and present in all yoga RDO repos
- Existing cinder.conf subscriptions handle the restarts (cinder-scheduler,
  cinder-volume, httpd reload for cinder-api); cinder-backup is not
  chef-managed
- Spec asserts the rendered URL; the multi-node env wires the controllers
  to the mq tier and inspec asserts the ini value
- Docs: HA migration D3 note on the mysql removal; coordination doc gains
  the per-cloud cutover and verification steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)