### PR TITLE
Tune nf_conntrack for multi-tenant KVM hypervisors

### DIFF
--- a/kitchen.openstack.yml
+++ b/kitchen.openstack.yml
@@ -9,7 +9,6 @@ driver:
   openstack_domain_name: <%= ENV['OS_USER_DOMAIN_NAME'] %>
   floating_ip_pool: <%= ENV['OS_FLOATING_IP_POOL'] %>
   network_ref: <%= ENV['OS_NETWORK_REF']  %>
-  flavor_ref: <%= ENV['OS_FLAVOR_REF'] %>
   availability_zone: <%= ENV['OS_AVAILABILITY_ZONE'] || 'nova' %>
   private_key_path: <%= ENV['OS_PRIVATE_SSH_KEY'] %>
   key_name: <%= ENV['OS_SSH_KEYPAIR'] %>

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -475,6 +475,23 @@ module OSLOpenstack
         end
       end
 
+      # Guest traffic is bridged through the host conntrack table, so 40+
+      # VMs per hypervisor outgrow the stock ceiling.
+      def openstack_conntrack_max
+        safe_dig(os_secrets, 'compute', 'conntrack', 'max') || 2_097_152
+      end
+
+      # Stock 432000 (5 days) is excessive and lets dead entries accumulate.
+      def openstack_conntrack_tcp_timeout_established
+        safe_dig(os_secrets, 'compute', 'conntrack', 'tcp_timeout_established') || 86_400
+      end
+
+      # The hashtable is a module parameter and does not scale with the
+      # sysctl, so size it off max unless overridden directly.
+      def openstack_conntrack_hashsize
+        safe_dig(os_secrets, 'compute', 'conntrack', 'hashsize') || openstack_conntrack_max / 4
+      end
+
       # OpenStack API helpers
       def os_conn
         return OSLOpenstack::Cookbook::Helpers.conn_cache if OSLOpenstack::Cookbook::Helpers.conn_cache

--- a/recipes/compute.rb
+++ b/recipes/compute.rb
@@ -189,6 +189,25 @@ end
 include_recipe 'osl-openstack::network'
 include_recipe 'osl-openstack::telemetry_compute'
 
+kernel_module 'nf_conntrack' do
+  options ["hashsize=#{openstack_conntrack_hashsize}"]
+  action [:install, :load]
+end
+
+sysctl 'net.netfilter.nf_conntrack_max' do
+  value openstack_conntrack_max
+end
+
+sysctl 'net.netfilter.nf_conntrack_tcp_timeout_established' do
+  value openstack_conntrack_tcp_timeout_established
+end
+
+# Applies hashsize without a reboot. The modprobe option above already covers
+# boot, so no persist here.
+osl_sysfs_param '/sys/module/nf_conntrack/parameters/hashsize' do
+  value openstack_conntrack_hashsize
+end
+
 unless openstack_cinder_disabled?
   package 'openstack-cinder'
 

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -137,6 +137,57 @@ describe OSLOpenstack::Cookbook::Helpers do
     end
   end
 
+  describe 'conntrack helpers' do
+    def stub_conntrack(conntrack)
+      allow(helper).to receive(:os_secrets).and_return(
+        'compute' => conntrack.nil? ? {} : { 'conntrack' => conntrack }
+      )
+    end
+
+    describe '#openstack_conntrack_max' do
+      it 'defaults when the conntrack block is absent' do
+        stub_conntrack(nil)
+        expect(helper.openstack_conntrack_max).to eq(2_097_152)
+      end
+
+      it 'returns the configured value' do
+        stub_conntrack('max' => 4_194_304)
+        expect(helper.openstack_conntrack_max).to eq(4_194_304)
+      end
+    end
+
+    describe '#openstack_conntrack_tcp_timeout_established' do
+      it 'defaults to a day rather than the kernel default of 5 days' do
+        stub_conntrack(nil)
+        expect(helper.openstack_conntrack_tcp_timeout_established).to eq(86_400)
+      end
+
+      it 'returns the configured value' do
+        stub_conntrack('tcp_timeout_established' => 43_200)
+        expect(helper.openstack_conntrack_tcp_timeout_established).to eq(43_200)
+      end
+    end
+
+    describe '#openstack_conntrack_hashsize' do
+      it 'derives a quarter of the default max' do
+        stub_conntrack(nil)
+        expect(helper.openstack_conntrack_hashsize).to eq(524_288)
+      end
+
+      # The hashtable does not scale with the sysctl, so an overridden max
+      # has to carry through to the module parameter.
+      it 'derives a quarter of an overridden max' do
+        stub_conntrack('max' => 4_194_304)
+        expect(helper.openstack_conntrack_hashsize).to eq(1_048_576)
+      end
+
+      it 'prefers an explicit hashsize over the derived value' do
+        stub_conntrack('max' => 4_194_304, 'hashsize' => 65_536)
+        expect(helper.openstack_conntrack_hashsize).to eq(65_536)
+      end
+    end
+  end
+
   describe '#openstack_rabbitmq_join_needed?' do
     let(:primary) { 'rabbit@mq1.bak.osuosl.org' }
 

--- a/spec/unit/recipes/compute_spec.rb
+++ b/spec/unit/recipes/compute_spec.rb
@@ -30,6 +30,22 @@ describe 'osl-openstack::compute' do
       end
       it { is_expected.to install_kernel_module 'tun' }
       it { is_expected.to load_kernel_module 'tun' }
+      it do
+        is_expected.to install_kernel_module('nf_conntrack').with(options: %w(hashsize=524288))
+      end
+      it { is_expected.to load_kernel_module 'nf_conntrack' }
+      # sysctl and osl_sysfs_param both coerce value to a String
+      it do
+        is_expected.to apply_sysctl('net.netfilter.nf_conntrack_max').with(value: '2097152')
+      end
+      it do
+        is_expected.to apply_sysctl('net.netfilter.nf_conntrack_tcp_timeout_established')
+          .with(value: '86400')
+      end
+      it do
+        is_expected.to set_osl_sysfs_param('/sys/module/nf_conntrack/parameters/hashsize')
+          .with(value: '524288')
+      end
       case pltfrm
       when ALMA_8
         it { is_expected.to create_cookbook_file '/etc/sysconfig/network' }

--- a/test/integration/compute/controls/compute_spec.rb
+++ b/test/integration/compute/controls/compute_spec.rb
@@ -162,6 +162,27 @@ control 'compute' do
     its('content') { should cmp "options kvm_intel nested=1\n" }
   end if os.arch == 'x86_64'
 
+  describe kernel_module('nf_conntrack') do
+    it { should be_loaded }
+  end
+
+  describe file '/etc/modprobe.d/options_nf_conntrack.conf' do
+    its('content') { should cmp "options nf_conntrack hashsize=524288\n" }
+  end
+
+  describe kernel_parameter('net.netfilter.nf_conntrack_max') do
+    its('value') { should eq 2097152 }
+  end
+
+  describe kernel_parameter('net.netfilter.nf_conntrack_tcp_timeout_established') do
+    its('value') { should eq 86400 }
+  end
+
+  # Applied at runtime, so it holds without the reboot the modprobe option needs
+  describe file '/sys/module/nf_conntrack/parameters/hashsize' do
+    its('content') { should cmp "524288\n" }
+  end
+
   if os.arch == 'ppc64le'
     describe kernel_module('kvm_hv') do
       it { should be_loaded }


### PR DESCRIPTION
A hypervisor hit the default `nf_conntrack_max` and started logging
`nf_conntrack: table full, dropping packet`. Guest traffic is bridged through
the host conntrack table, so 40+ VMs per host outgrow the stock ceiling through
ordinary growth rather than any single abuser. This is capacity tuning plus the
monitoring to see it coming next time.

Scoped to `osl-openstack::compute` only, not the base role, since the values are
sized for multi-tenant KVM hosts.

## What changed

Three helpers read `compute.conntrack` out of the data bag and fall back to
defaults:

| setting | default | why |
| --- | --- | --- |
| `nf_conntrack_max` | 2097152 | headroom for 40+ bridged guests |
| `nf_conntrack_tcp_timeout_established` | 86400 | stock 432000 (5 days) lets dead entries accumulate |
| hashsize | `max / 4` | module parameter, does not scale with the sysctl |

hashsize derives from max rather than being hardcoded alongside it, so
overriding max alone resizes the table too. An explicit `hashsize` still wins if
a host needs the two decoupled.

## Why hashsize is applied twice

Two different moments, not redundancy:

- `kernel_module` `options` writes `/etc/modprobe.d/options_nf_conntrack.conf`
  and triggers dracut, covering module load at boot.
- That does nothing for the already-loaded module on a running host, so
  `osl_sysfs_param` writes `/sys/module/nf_conntrack/parameters/hashsize` to
  resize it now, guarded so a matching value is a no-op.

No `persist` on the sysfs write, since the modprobe option already owns boot.

## Not in this PR

Monitoring. `check_conntrack_usage` ships globally from osl-nrpe, warning at 70%
and critical at 85% of count over max. `osl_sysfs_param` landed in osl-resources.

## Also here

An unrelated kitchen fix in its own commit. `kitchen.openstack.yml` re-declared
`flavor_ref` from the normally-unset `OS_FLAVOR_REF`, so the merge put an empty
value over the `kitchen.yml` flavors and instances came up on the provider
default with too little RAM.

## Test plan

- [x] `cinc exec rspec` green, 1432 examples 0 failures
- [x] `cinc exec cookstyle` clean
- [x] Unit coverage for the helper defaults, overrides, and the `max / 4`
      derivation, plus the recipe resources
- [x] Integration controls added for the module options file, both sysctls and
      the live `/sys` value, but they need a kitchen converge on a real host
      since conntrack cannot be exercised in a container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
